### PR TITLE
docs: reorganize documentation into focused pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,34 @@
 # ai-dungeon
 
-Multi-workspace terminal for AI agents and CLIs.
+A desktop tool for managing AI CLIs like [Claude Code](https://claude.com/claude-code) and [OpenCode](https://opencode.ai/) — a multi-workspace terminal environment where developers can launch, organize, and interact with multiple AI CLI sessions side by side.
 
-## Tech Stack
+## Why ai-dungeon?
 
-| Layer           | Technology                                |
-| --------------- | ----------------------------------------- |
-| Desktop shell   | [Tauri v2](https://v2.tauri.app/)         |
-| Frontend        | React 19 + TypeScript                     |
-| UI library      | [Mantine v8](https://v8.mantine.dev/)     |
-| Bundler         | Vite 7 (PostCSS via `postcss.config.cjs`) |
-| Package manager | pnpm                                      |
-| Backend         | Rust (Cargo)                              |
+AI coding assistants increasingly run as CLIs that hold long-lived, stateful sessions. Juggling several of them across projects in plain terminal tabs is awkward: sessions get lost, context is hard to keep separate, and switching between agents breaks flow. ai-dungeon gives each agent and each project a dedicated workspace inside one native desktop app, so you can keep multiple AI sessions running, organized, and reachable at a glance.
 
-## Project Structure
+## Key Features
 
-```
-ai-dungeon/
-├── src/              # React + TypeScript frontend
-│   ├── main.tsx      # Entry point — mounts MantineProvider
-│   ├── App.tsx       # Root component — wrapped in AppLayout
-│   └── components/
-│       └── layout/
-│           ├── AppLayout.tsx  # AppShell layout (header, navbar, main)
-│           └── index.ts       # Barrel export
-├── src-tauri/        # Rust backend (Tauri)
-│   ├── src/
-│   │   ├── main.rs   # Binary entry point
-│   │   └── lib.rs    # Library crate (command handlers)
-│   ├── capabilities/ # Tauri permission grants
-│   ├── icons/        # App icons (all sizes)
-│   ├── Cargo.toml
-│   └── tauri.conf.json
-├── index.html
-├── vite.config.ts
-├── tsconfig.json
-└── package.json
-```
+- **Multi-workspace layout** — organize AI CLI sessions per project or per agent.
+- **Multiple AI CLIs in one place** — designed to host tools like Claude Code, OpenCode, and other terminal-based AI assistants.
+- **Native desktop app** — built on Tauri v2 for a fast, lightweight shell around a modern web UI.
+- **Secure by default** — restrictive Content Security Policy and minimal Tauri capabilities out of the box. See [docs/security.md](docs/security.md).
 
-## Prerequisites
-
-- **Rust** — install via rustup:
-  ```sh
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-  ```
-- **Node.js** v18 or later
-- **pnpm**:
-  ```sh
-  npm install -g pnpm
-  ```
-
-## Development
-
-Install dependencies:
+## Quick Start
 
 ```sh
 pnpm install
-```
-
-Start the Vite dev server and open the native window:
-
-```sh
 pnpm tauri dev
 ```
 
-The Vite dev server runs on port 1420. The Rust backend is compiled on first run, which takes a few minutes while Cargo downloads crates.
+This installs dependencies and launches the app in development mode. You will need Rust, Node.js v18+, and pnpm installed first — see [docs/getting-started.md](docs/getting-started.md) for full prerequisites and setup instructions.
 
-### Code Quality
+## Documentation
 
-The project uses [Oxlint](https://oxc.rs/docs/guide/usage/linter) for linting and [Oxfmt](https://oxc.rs/docs/guide/usage/formatter) for formatting.
-
-| Command             | Effect                           |
-| ------------------- | -------------------------------- |
-| `pnpm lint`         | Lint the codebase                |
-| `pnpm lint:fix`     | Lint and auto-fix violations     |
-| `pnpm format`       | Format all files in-place        |
-| `pnpm format:check` | Check formatting without writing |
+- [Getting Started](docs/getting-started.md) — prerequisites, development workflow, and code quality tooling.
+- [Tech Stack](docs/tech-stack.md) — the libraries and tools that power ai-dungeon.
+- [Project Structure](docs/project-structure.md) — directory layout and key files.
+- [Build](docs/build.md) — producing a release binary.
+- [Security Notes](docs/security.md) — CSP and Tauri capability defaults.
 
 ## Testing
 
@@ -90,22 +43,6 @@ See [TESTING.md](TESTING.md) for the full guide, including setup, configuration 
 - **Unit/component tests** (Vitest + React Testing Library) live in `src/` alongside source files.
 - **E2E tests** (Playwright) live in `e2e/` and run against the Vite dev server, not the compiled Tauri backend.
 
-## CI
+## License
 
-GitHub Actions runs lint, format check, and unit tests on every pull request and push to `main`. See [`.github/workflows/test.yml`](.github/workflows/test.yml) for the workflow definition.
-
-The Node.js version is pinned in [`.node-version`](.node-version) and read by both `actions/setup-node` and local tooling.
-
-## Build
-
-Produce a release binary (and `.app` bundle on macOS):
-
-```sh
-pnpm tauri build
-```
-
-Output is placed under `src-tauri/target/release/`.
-
-## Security Notes
-
-The app ships with a restrictive Content Security Policy that limits sources to `'self'` and the Tauri IPC/asset origins. Tauri capabilities are scoped to `core:default` only — no filesystem, shell, or HTTP client permissions are granted by default. Both are intentional baselines; extend them in `src-tauri/capabilities/` and `tauri.conf.json` as features are added.
+See [LICENSE](LICENSE).

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,9 @@
+# Build
+
+Produce a release binary (and `.app` bundle on macOS):
+
+```sh
+pnpm tauri build
+```
+
+Output is placed under `src-tauri/target/release/`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+## Prerequisites
+
+- **Rust** — install via rustup:
+  ```sh
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+  ```
+- **Node.js** v18 or later
+- **pnpm**:
+  ```sh
+  npm install -g pnpm
+  ```
+
+## Development
+
+Install dependencies:
+
+```sh
+pnpm install
+```
+
+Start the Vite dev server and open the native window:
+
+```sh
+pnpm tauri dev
+```
+
+The Vite dev server runs on port 1420. The Rust backend is compiled on first run, which takes a few minutes while Cargo downloads crates.
+
+### Code Quality
+
+The project uses [Oxlint](https://oxc.rs/docs/guide/usage/linter) for linting and [Oxfmt](https://oxc.rs/docs/guide/usage/formatter) for formatting.
+
+| Command             | Effect                           |
+| ------------------- | -------------------------------- |
+| `pnpm lint`         | Lint the codebase                |
+| `pnpm lint:fix`     | Lint and auto-fix violations     |
+| `pnpm format`       | Format all files in-place        |
+| `pnpm format:check` | Check formatting without writing |

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,24 @@
+# Project Structure
+
+```
+ai-dungeon/
+├── src/              # React + TypeScript frontend
+│   ├── main.tsx      # Entry point — mounts MantineProvider
+│   ├── App.tsx       # Root component — wrapped in AppLayout
+│   └── components/
+│       └── layout/
+│           ├── AppLayout.tsx  # AppShell layout (header, navbar, main)
+│           └── index.ts       # Barrel export
+├── src-tauri/        # Rust backend (Tauri)
+│   ├── src/
+│   │   ├── main.rs   # Binary entry point
+│   │   └── lib.rs    # Library crate (command handlers)
+│   ├── capabilities/ # Tauri permission grants
+│   ├── icons/        # App icons (all sizes)
+│   ├── Cargo.toml
+│   └── tauri.conf.json
+├── index.html
+├── vite.config.ts
+├── tsconfig.json
+└── package.json
+```

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,3 @@
+# Security Notes
+
+The app ships with a restrictive Content Security Policy that limits sources to `'self'` and the Tauri IPC/asset origins. Tauri capabilities are scoped to `core:default` only — no filesystem, shell, or HTTP client permissions are granted by default. Both are intentional baselines; extend them in `src-tauri/capabilities/` and `tauri.conf.json` as features are added.

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,0 +1,10 @@
+# Tech Stack
+
+| Layer           | Technology                                |
+| --------------- | ----------------------------------------- |
+| Desktop shell   | [Tauri v2](https://v2.tauri.app/)         |
+| Frontend        | React 19 + TypeScript                     |
+| UI library      | [Mantine v8](https://v8.mantine.dev/)     |
+| Bundler         | Vite 7 (PostCSS via `postcss.config.cjs`) |
+| Package manager | pnpm                                      |
+| Backend         | Rust (Cargo)                              |


### PR DESCRIPTION
The README previously mixed project identity with implementation details, making it harder for new visitors to understand what ai-dungeon is before seeing tech choices. This PR splits the technical content into focused docs/ pages and rewrites the README to lead with the project's purpose — a desktop tool for managing AI CLIs like Claude Code and OpenCode — with the tech details one click away.