### PR TITLE
feat(ui): add card list to navbar with app-level state

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -4,11 +4,19 @@
 ai-dungeon/
 ├── src/              # React + TypeScript frontend
 │   ├── main.tsx      # Entry point — mounts MantineProvider
-│   ├── App.tsx       # Root component — wrapped in AppLayout
-│   └── components/
-│       └── layout/
-│           ├── AppLayout.tsx  # AppShell layout (header, navbar, main)
-│           └── index.ts       # Barrel export
+│   ├── App.tsx       # Root component; owns card list state
+│   ├── App.test.tsx
+│   ├── types/
+│   │   └── card.ts   # Card interface (shared across components)
+│   ├── components/
+│   │   └── layout/
+│   │       ├── AppLayout.tsx  # AppShell layout; forwards card props to NavBar
+│   │       ├── NavBar.tsx     # Controlled card list — add/remove via callbacks
+│   │       ├── NavBar.test.tsx
+│   │       └── index.ts       # Barrel export
+│   └── test-utils/
+│       ├── render.tsx  # renderWithProviders helper (wraps MantineProvider)
+│       └── setup.ts    # Vitest setup file
 ├── src-tauri/        # Rust backend (Tauri)
 │   ├── src/
 │   │   ├── main.rs   # Binary entry point

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "./test-utils/render";
 import App from "./App";
 
@@ -14,5 +15,19 @@ describe("App", () => {
     expect(
       screen.getByText("Multi-workspace terminal for AI agents and CLIs."),
     ).toBeInTheDocument();
+  });
+
+  it("adds and removes a card via the navbar", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    const removeButton = screen.getByRole("button", { name: /Remove card/i });
+    expect(removeButton).toBeInTheDocument();
+
+    await user.click(removeButton);
+
+    expect(screen.queryByRole("button", { name: /Remove card/i })).toBeNull();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,20 @@
+import { useCallback, useState } from "react";
 import { AppLayout } from "./components/layout";
+import type { Card } from "./types/card";
 
 function App() {
+  const [cards, setCards] = useState<Card[]>([]);
+
+  const addCard = useCallback(() => {
+    setCards((prev) => [...prev, { id: globalThis.crypto.randomUUID() }]);
+  }, []);
+
+  const removeCard = useCallback((id: string) => {
+    setCards((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
   return (
-    <AppLayout>
+    <AppLayout cards={cards} onAddCard={addCard} onRemoveCard={removeCard}>
       <h1>AI Dungeon</h1>
       <p>Multi-workspace terminal for AI agents and CLIs.</p>
     </AppLayout>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,12 +1,18 @@
 import { AppShell, Burger, Group, Title } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import type { ReactNode } from "react";
+import type { Card } from "../../types/card";
+import { NavBar } from "./NavBar";
 
+// cards props are required; only consumer is App.tsx (YAGNI — make optional if a second consumer is added)
 interface AppLayoutProps {
   children: ReactNode;
+  cards: Card[];
+  onAddCard: () => void;
+  onRemoveCard: (id: string) => void;
 }
 
-export function AppLayout({ children }: AppLayoutProps) {
+export function AppLayout({ children, cards, onAddCard, onRemoveCard }: AppLayoutProps) {
   const [opened, { toggle }] = useDisclosure(true);
 
   return (
@@ -27,7 +33,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       </AppShell.Header>
 
       <AppShell.Navbar p="md">
-        <p>Navbar content</p>
+        <NavBar cards={cards} onAddCard={onAddCard} onRemoveCard={onRemoveCard} />
       </AppShell.Navbar>
 
       <AppShell.Main>{children}</AppShell.Main>

--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { renderWithProviders } from "../../test-utils/render";
+import { NavBar } from "./NavBar";
+
+describe("NavBar", () => {
+  it("renders empty state when no cards are provided", () => {
+    renderWithProviders(<NavBar cards={[]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />);
+
+    expect(screen.getByText("No cards yet")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove card/i })).toBeNull();
+  });
+
+  it("renders provided cards with remove buttons", () => {
+    renderWithProviders(
+      <NavBar cards={[{ id: "a" }, { id: "b" }]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Remove card a" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove card b" })).toBeInTheDocument();
+  });
+
+  it("calls onAddCard when the Add card button is clicked", async () => {
+    const onAddCard = vi.fn();
+    const onRemoveCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(<NavBar cards={[]} onAddCard={onAddCard} onRemoveCard={onRemoveCard} />);
+
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    expect(onAddCard).toHaveBeenCalledTimes(1);
+    expect(onRemoveCard).not.toHaveBeenCalled();
+  });
+
+  it("calls onRemoveCard with the correct id when a close button is clicked", async () => {
+    const onRemoveCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <NavBar cards={[{ id: "a" }, { id: "b" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove card a" }));
+
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+    expect(onRemoveCard).toHaveBeenCalledWith("a");
+  });
+});

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,0 +1,50 @@
+import {
+  ActionIcon,
+  Card as MantineCard,
+  CloseButton,
+  Group,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import type { Card } from "../../types/card";
+
+interface NavBarProps {
+  cards: Card[];
+  onAddCard: () => void;
+  onRemoveCard: (id: string) => void;
+}
+
+export function NavBar({ cards, onAddCard, onRemoveCard }: NavBarProps) {
+  return (
+    <>
+      <Group justify="space-between">
+        <Title order={5}>Cards</Title>
+        <ActionIcon aria-label="Add card" variant="default" onClick={onAddCard}>
+          +
+        </ActionIcon>
+      </Group>
+
+      {cards.length === 0 ? (
+        <Text size="sm" c="dimmed">
+          No cards yet
+        </Text>
+      ) : (
+        <Stack gap="xs">
+          {cards.map((card) => (
+            <MantineCard key={card.id}>
+              <Group justify="space-between">
+                <Text>Card {card.id.slice(0, 8)}</Text>
+                {/* TODO: switch to card.title once Card gains a human-readable title field */}
+                <CloseButton
+                  aria-label={`Remove card ${card.id}`}
+                  onClick={() => onRemoveCard(card.id)}
+                />
+              </Group>
+            </MantineCard>
+          ))}
+        </Stack>
+      )}
+    </>
+  );
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,1 +1,2 @@
 export { AppLayout } from "./AppLayout";
+export { NavBar } from "./NavBar";

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,0 +1,4 @@
+// Additional fields (e.g. title, kind) will be added when card content is introduced.
+export interface Card {
+  id: string;
+}


### PR DESCRIPTION
Introduces a card list in the NavBar — a '+' button appends cards; each card has an 'x' to remove it. State lives in App.tsx so other components (e.g., the main pane) can consume the same list without a refactor. Uses Mantine v8 primitives; no new dependencies.