### PR TITLE
chore: ignore .worktrees/ directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ src-tauri/target/
 coverage/
 test-results/
 playwright-report/
+
+# AI tooling
+.worktrees/


### PR DESCRIPTION
Prevents git from reporting .worktrees/ directories as untracked. These directories are created by the AI-assisted development workflow for isolated feature branches and should not be tracked or committed.