### PR TITLE
chore: add pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
-allowBuilds:
-  esbuild: true
+# Allows esbuild's postinstall script to run (pnpm v10+ blocks build scripts by default).
+onlyBuiltDependencies:
+  - esbuild


### PR DESCRIPTION
pnpm v10+ silently skips install scripts for packages that are not explicitly allowlisted. Without this file, esbuild's install script is ignored, causing "ignored build scripts" warnings during pnpm install and potentially leaving the esbuild binary unbuilt.

## Test plan

- [ ] Run `pnpm install` and verify no "ignored build scripts" warning appears for esbuild
- [ ] Confirm esbuild binary is present and functional after install
