### PR TITLE
fix(terminal): surface pty write errors and buffer pre-ready keystrokes

### DIFF
--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -81,6 +81,12 @@ describe("Terminal", () => {
     // Clear captured unlisten spies from the previous test.
     unlistenSpies.length = 0;
 
+    // Restore invoke to its default behavior (resolves immediately) so that
+    // tests which set a persistent mockImplementation (e.g. the "does NOT call
+    // pty_resize before spawn completes" test) do not leak state into later
+    // tests. vi.clearAllMocks() only clears call history, not implementations.
+    (invoke as unknown as AnyMock).mockResolvedValue(undefined);
+
     // Restore a fresh ResizeObserver spy for each test.
     globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
       return {
@@ -123,9 +129,19 @@ describe("Terminal", () => {
   it("registers onData handler and forwards input as base64 via pty_write", async () => {
     renderWithProviders(<Terminal />);
 
-    // Wait for the IIFE to complete (isReadyRef set, onData registered).
+    // After the refactor, onData is registered synchronously at mount (before
+    // fitAddon.fit()). Wait for it to have been registered.
     await vi.waitFor(() => {
       expect(onDataSpy).toHaveBeenCalled();
+    });
+
+    // The callback is registered immediately but forwards keystrokes only once
+    // isReadyRef.current is true (after spawn + listen calls resolve). Wait for
+    // listen() to have been called before extracting and invoking the callback,
+    // so that we exercise the live-path (not the buffering path).
+    const mockListen = listen as unknown as AnyMock;
+    await vi.waitFor(() => {
+      expect(mockListen).toHaveBeenCalledTimes(2);
     });
 
     // Extract the onData callback and simulate a keystroke ('a').
@@ -239,9 +255,12 @@ describe("Terminal", () => {
 
     renderWithProviders(<Terminal />);
 
-    // Wait for spawn to complete so isReadyRef.current = true.
+    // After the refactor, onData is registered synchronously (before spawn).
+    // Wait for both listen() calls to resolve, which confirms isReadyRef.current
+    // has been set to true (spawn + subscriptions complete).
+    const mockListen = listen as unknown as AnyMock;
     await vi.waitFor(() => {
-      expect(onDataSpy).toHaveBeenCalled();
+      expect(mockListen).toHaveBeenCalledTimes(2);
     });
 
     // Trigger a resize after ready.
@@ -308,5 +327,201 @@ describe("Terminal", () => {
       MockResizeObserver.mock.results[MockResizeObserver.mock.results.length - 1].value;
     expect(termInstance.dispose).toHaveBeenCalledTimes(1);
     expect(observerInstance.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Pre-ready keystroke buffering ─────────────────────────────────────────
+
+  it("buffers keystrokes typed before spawn completes and flushes them in order after spawn resolves", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+
+    // Deferred spawn: resolves only when we call resolveSpawn().
+    let resolveSpawn!: () => void;
+    const spawnPromise = new Promise<void>((resolve) => {
+      resolveSpawn = resolve;
+    });
+
+    // First invoke call is pty_spawn; all subsequent calls resolve immediately.
+    mockInvoke.mockImplementationOnce(() => spawnPromise);
+
+    renderWithProviders(<Terminal />);
+
+    // onData is now registered synchronously — wait for registration.
+    await vi.waitFor(() => {
+      expect(onDataSpy).toHaveBeenCalled();
+    });
+
+    // Extract the callback (registered before spawn resolves — buffering path).
+    const onDataCallback = onDataSpy.mock.calls[onDataSpy.mock.calls.length - 1][0] as (
+      data: string,
+    ) => void;
+
+    // Type three keys before spawn resolves.
+    onDataCallback("a");
+    onDataCallback("b");
+    onDataCallback("c");
+
+    // pty_write must NOT have been called yet — keystrokes are buffered.
+    const ptyWriteCallsBefore = mockInvoke.mock.calls.filter(
+      (c: unknown[]) => c[0] === "pty_write",
+    );
+    expect(ptyWriteCallsBefore).toHaveLength(0);
+
+    // Resolve spawn and wait for the flush loop to drain.
+    await act(async () => {
+      resolveSpawn();
+      await spawnPromise;
+    });
+
+    // After spawn + listen calls complete, all three buffered keystrokes must
+    // have been flushed to pty_write in FIFO order.
+    await vi.waitFor(() => {
+      const ptyWriteCalls = mockInvoke.mock.calls
+        .filter((c: unknown[]) => c[0] === "pty_write")
+        .map((c: unknown[]) => (c[1] as { data_b64: string }).data_b64);
+      expect(ptyWriteCalls).toEqual(["YQ==", "Yg==", "Yw=="]);
+    });
+  });
+
+  it("does not replay buffered keystrokes if the component unmounts before spawn completes", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+
+    // Deferred spawn.
+    let resolveSpawn!: () => void;
+    const spawnPromise = new Promise<void>((resolve) => {
+      resolveSpawn = resolve;
+    });
+
+    mockInvoke.mockImplementationOnce(() => spawnPromise);
+
+    const { unmount } = renderWithProviders(<Terminal />);
+
+    // Wait for synchronous onData registration.
+    await vi.waitFor(() => {
+      expect(onDataSpy).toHaveBeenCalled();
+    });
+
+    const onDataCallback = onDataSpy.mock.calls[onDataSpy.mock.calls.length - 1][0] as (
+      data: string,
+    ) => void;
+
+    // Buffer a keystroke before spawn resolves.
+    onDataCallback("x");
+
+    // Unmount before spawn resolves — cleanup fires, pendingWrites is cleared.
+    act(() => {
+      unmount();
+    });
+
+    // Now resolve spawn — the IIFE resumes but cancelled is true; flush loop
+    // checks cancelled and breaks immediately without calling pty_write.
+    await act(async () => {
+      resolveSpawn();
+      await spawnPromise;
+    });
+
+    // pty_write must NEVER have been called.
+    const ptyWriteCalls = mockInvoke.mock.calls.filter((c: unknown[]) => c[0] === "pty_write");
+    expect(ptyWriteCalls).toHaveLength(0);
+  });
+
+  // ── pty_write error surfacing ─────────────────────────────────────────────
+
+  it("surfaces pty_write errors via term.writeln", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+
+    renderWithProviders(<Terminal />);
+
+    // Wait for the PTY to be ready (both listen() calls resolved).
+    const mockListen = listen as unknown as AnyMock;
+    await vi.waitFor(() => {
+      expect(mockListen).toHaveBeenCalledTimes(2);
+    });
+
+    const termInstance = getTermInstance();
+
+    // Configure the next pty_write call to reject.
+    mockInvoke.mockImplementationOnce((cmd: string) => {
+      if (cmd === "pty_write") return Promise.reject(new Error("write failed"));
+      return Promise.resolve(undefined);
+    });
+
+    // Extract the onData callback and trigger a keystroke on the live path.
+    const onDataCallback = onDataSpy.mock.calls[onDataSpy.mock.calls.length - 1][0] as (
+      data: string,
+    ) => void;
+    onDataCallback("a");
+
+    // The .catch handler must surface the error via term.writeln.
+    await vi.waitFor(() => {
+      expect(termInstance.writeln).toHaveBeenCalledWith(
+        expect.stringContaining("[pty write failed:"),
+      );
+    });
+    expect(termInstance.writeln).toHaveBeenCalledWith(expect.stringContaining("write failed"));
+  });
+
+  it("does not call term.writeln on pty_write error after unmount (flush-path .catch cancelled guard)", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+
+    // Deferred spawn so we can queue a keystroke before spawn resolves.
+    let resolveSpawn!: () => void;
+    const spawnPromise = new Promise<void>((resolve) => {
+      resolveSpawn = resolve;
+    });
+
+    mockInvoke.mockImplementationOnce(() => spawnPromise);
+
+    const { unmount } = renderWithProviders(<Terminal />);
+
+    // Wait for synchronous onData registration.
+    await vi.waitFor(() => {
+      expect(onDataSpy).toHaveBeenCalled();
+    });
+
+    const onDataCallback = onDataSpy.mock.calls[onDataSpy.mock.calls.length - 1][0] as (
+      data: string,
+    ) => void;
+
+    // Queue a keystroke before spawn resolves — it will be flushed after spawn.
+    onDataCallback("a");
+
+    const termInstance = getTermInstance();
+
+    // Set up a deferred pty_write rejection that we control manually.
+    let rejectPtyWrite!: (err: Error) => void;
+    const ptyWritePromise = new Promise<void>((_, reject) => {
+      rejectPtyWrite = reject;
+    });
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "pty_write") return ptyWritePromise;
+      return Promise.resolve(undefined);
+    });
+
+    // Resolve spawn — flush loop runs, calls pty_write (promise is still pending).
+    await act(async () => {
+      resolveSpawn();
+      await spawnPromise;
+    });
+
+    // Unmount BEFORE settling the pty_write rejection — cancelled becomes true.
+    act(() => {
+      unmount();
+    });
+
+    // Now reject pty_write — the .catch fires with cancelled=true.
+    await act(async () => {
+      rejectPtyWrite(new Error("write failed"));
+      await ptyWritePromise.catch(() => {
+        /* expected rejection, suppress unhandled-rejection noise */
+      });
+    });
+
+    // The flush-path .catch must NOT call writeln because cancelled is true.
+    expect(termInstance.writeln).not.toHaveBeenCalledWith(
+      expect.stringContaining("[pty write failed:"),
+    );
+    // Dispose must have been called exactly once.
+    expect(termInstance.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -27,11 +27,58 @@ export function Terminal() {
     // Collect the onData disposable for cleanup.
     let onDataDisposable: { dispose: () => void } | undefined;
 
+    // Buffer for keystrokes that arrive before the PTY is ready. Each entry is
+    // a discrete xterm onData string and is encoded + sent independently to
+    // preserve per-keystroke handling semantics.
+    const pendingWrites: string[] = [];
+
     // ── Terminal & FitAddon ───────────────────────────────────────────────────
     const term = new XTerm();
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(containerRef.current);
+
+    // ── encodeBase64 helper ───────────────────────────────────────────────────
+    // Encodes a xterm data string to UTF-8 bytes, then base64. Returns the
+    // base64 string.
+    //
+    // btoa() is called once on the fully concatenated `bin` string (not per
+    // chunk). Chunking exists solely to avoid stack overflow in
+    // String.fromCharCode.apply, which has a call-stack limit on large arrays.
+    const encoder = new TextEncoder();
+    function encodeBase64(data: string): string {
+      const bytes = encoder.encode(data);
+      // Chunked base64 encoding to handle large paste payloads safely.
+      // String.fromCharCode.apply has a stack limit; process in 8 KiB chunks.
+      const CHUNK = 8192;
+      let bin = "";
+      for (let offset = 0; offset < bytes.length; offset += CHUNK) {
+        const chunk = bytes.subarray(offset, offset + CHUNK);
+        bin += String.fromCharCode.apply(null, chunk as unknown as number[]);
+      }
+      return btoa(bin);
+    }
+
+    // ── Register onData synchronously ─────────────────────────────────────────
+    // Registered here (before fitAddon.fit() and before the async IIFE) so that
+    // keystrokes typed during the spawn window are captured rather than dropped.
+    // While isReadyRef.current is false, keystrokes are buffered into
+    // pendingWrites. Once the PTY is ready, keystrokes are forwarded live.
+    onDataDisposable = term.onData((data) => {
+      if (!isReadyRef.current) {
+        pendingWrites.push(data);
+        return;
+      }
+      const data_b64 = encodeBase64(data);
+      invoke("pty_write", { sessionId, data_b64 }).catch((err) => {
+        // Guard with `cancelled` for defence-in-depth: onDataDisposable.dispose()
+        // prevents new callbacks from firing after unmount, but in-flight invoke()
+        // promises that were already initiated before dispose() can still settle.
+        if (!cancelled) {
+          term.writeln(`\r\n[pty write failed: ${String(err)}]`);
+        }
+      });
+    });
 
     // FitAddon.fit() returns silently when dimensions are zero (not a throw).
     fitAddon.fit();
@@ -108,32 +155,40 @@ export function Terminal() {
 
       if (cancelled) return;
 
-      // ── Register onData: forward keystrokes to the PTY ─────────────────────
-      // Encode the xterm string to UTF-8 bytes via TextEncoder, then base64.
-      // This guarantees binary fidelity for alt-key sequences, mouse reporting,
-      // paste of binary content, and non-UTF-8 readline responses. (M-4)
-      const encoder = new TextEncoder();
-      onDataDisposable = term.onData((data) => {
-        const bytes = encoder.encode(data);
-        // Chunked base64 encoding to handle large paste payloads safely.
-        // String.fromCharCode.apply has a stack limit; process in 8 KiB chunks.
-        const CHUNK = 8192;
-        let bin = "";
-        for (let offset = 0; offset < bytes.length; offset += CHUNK) {
-          const chunk = bytes.subarray(offset, offset + CHUNK);
-          bin += String.fromCharCode.apply(null, chunk as unknown as number[]);
-        }
-        const data_b64 = btoa(bin);
-
-        void invoke("pty_write", { sessionId, data_b64 });
-      });
+      // ── Flush buffered pre-ready keystrokes ────────────────────────────────
+      // Drain pendingWrites in FIFO order before setting isReadyRef.current.
+      // The loop body is fully synchronous, so no keystroke event can interleave
+      // between iterations. Setting isReadyRef.current after the flush ensures
+      // live writes begin only after all buffered ones are sent.
+      while (pendingWrites.length > 0) {
+        // Check cancelled at the top of each iteration to avoid issuing
+        // redundant pty_write IPC calls to a session being concurrently killed.
+        // (F-2: this ordering is load-bearing for the .catch guard below.)
+        if (cancelled) break;
+        const data = pendingWrites.shift()!;
+        const data_b64 = encodeBase64(data);
+        invoke("pty_write", { sessionId, data_b64 }).catch((err) => {
+          // Guard with `cancelled` because term may be disposed by the time
+          // this .catch fires (cleanup sets cancelled = true before term.dispose()).
+          if (!cancelled) {
+            term.writeln(`\r\n[pty write failed: ${String(err)}]`);
+          }
+        });
+      }
 
       isReadyRef.current = true;
     })();
 
     // ── Cleanup ───────────────────────────────────────────────────────────────
     return () => {
+      // Set cancelled = true BEFORE term.dispose() so that any in-flight
+      // pty_write .catch callbacks (flush-loop path) see cancelled = true and
+      // skip the term.writeln call on the already-disposed terminal.
+      // This ordering is load-bearing for the cancelled guard in the flush loop.
       cancelled = true;
+      // Clear the pending queue so a remount does not replay stale input from
+      // this unmounted instance.
+      pendingWrites.length = 0;
       observer.disconnect();
       onDataDisposable?.dispose();
       unlistenOutput?.();
@@ -148,6 +203,13 @@ export function Terminal() {
   // The cleanup (dispose + disconnect) handles this correctly.
   // In DevTools, verify that exactly one element with data-testid="terminal-root"
   // exists after initial render.
+  //
+  // Note on minHeight: 0 here vs. AppShell.Main:
+  // - AppShell.Main has minHeight: 0 so it can flex-shrink within the AppShell
+  //   flex column and not overflow the viewport.
+  // - This inner div has minHeight: 0 so it can flex-shrink within AppShell.Main
+  //   (which itself is a flex column). Both are required for height: 100% on this
+  //   div to resolve to a definite non-zero value.
   return (
     <div
       ref={containerRef}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -29,6 +29,12 @@ export function AppLayout({ children, cards, onAddCard, onRemoveCard }: AppLayou
           display: "flex",
           flexDirection: "column",
           height: "calc(100vh - var(--app-shell-header-height, 60px))",
+          // Required so AppShell.Main can flex-shrink within the AppShell flex
+          // column and not force the layout taller than the viewport. The
+          // Terminal div inside also has minHeight: 0 for the same reason at
+          // the next level of the flex chain — both are needed for height: 100%
+          // on the Terminal container to resolve to a definite non-zero value.
+          minHeight: 0,
         },
       }}
     >


### PR DESCRIPTION
Pressing Enter (and any other key) in the xterm.js terminal produced no visible reaction due to three compounding issues: `pty_write` errors were silently swallowed via `void invoke(...)`, the `onData` handler was registered only after two async awaits (dropping keystrokes typed during startup), and `AppShell.Main` did not propagate a definite height to the terminal container.

Fixes all three: errors now surface via `term.writeln`, keystrokes typed before the PTY is ready are buffered and flushed in order once the session is established, and the flex layout correctly sizes the terminal to fill the available space.