### PR TITLE
fix(terminal): use camelCase dataB64 key in pty_write invocation

### DIFF
--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -153,7 +153,7 @@ describe("Terminal", () => {
     await vi.waitFor(() => {
       expect(invoke).toHaveBeenCalledWith("pty_write", {
         sessionId: "00000000-0000-0000-0000-000000000001",
-        data_b64: "YQ==",
+        dataB64: "YQ==",
       });
     });
   });
@@ -377,7 +377,7 @@ describe("Terminal", () => {
     await vi.waitFor(() => {
       const ptyWriteCalls = mockInvoke.mock.calls
         .filter((c: unknown[]) => c[0] === "pty_write")
-        .map((c: unknown[]) => (c[1] as { data_b64: string }).data_b64);
+        .map((c: unknown[]) => (c[1] as { dataB64: string }).dataB64);
       expect(ptyWriteCalls).toEqual(["YQ==", "Yg==", "Yw=="]);
     });
   });

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -69,8 +69,8 @@ export function Terminal() {
         pendingWrites.push(data);
         return;
       }
-      const data_b64 = encodeBase64(data);
-      invoke("pty_write", { sessionId, data_b64 }).catch((err) => {
+      const dataB64 = encodeBase64(data);
+      invoke("pty_write", { sessionId, dataB64 }).catch((err) => {
         // Guard with `cancelled` for defence-in-depth: onDataDisposable.dispose()
         // prevents new callbacks from firing after unmount, but in-flight invoke()
         // promises that were already initiated before dispose() can still settle.
@@ -166,8 +166,8 @@ export function Terminal() {
         // (F-2: this ordering is load-bearing for the .catch guard below.)
         if (cancelled) break;
         const data = pendingWrites.shift()!;
-        const data_b64 = encodeBase64(data);
-        invoke("pty_write", { sessionId, data_b64 }).catch((err) => {
+        const dataB64 = encodeBase64(data);
+        invoke("pty_write", { sessionId, dataB64 }).catch((err) => {
           // Guard with `cancelled` because term may be disposed by the time
           // this .catch fires (cleanup sets cancelled = true before term.dispose()).
           if (!cancelled) {


### PR DESCRIPTION
Tauri 2's `#[tauri::command]` macro maps camelCase JS keys to snake_case Rust parameters. The frontend was passing `data_b64` (snake_case literal) instead of the required `dataB64` (camelCase), causing every keypress in the terminal to fail with "missing required key dataB64" and no input reaching the PTY.

Fix renames the key at both call sites in `Terminal.tsx` and updates the corresponding test assertions in `Terminal.test.tsx` to match the production contract.
