### PR TITLE
feat(terminal): wire navbar cards as Tabs linked to per-card Terminal instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@ AI coding assistants increasingly run as CLIs that hold long-lived, stateful ses
 
 ## Key Features
 
-- **Multi-workspace layout** — organize AI CLI sessions per project or per agent.
+- **Card-as-tab terminals** — each card in the sidebar is a vertical tab; clicking it switches which terminal is visible in the main pane. PTY sessions are preserved across switches — the shell keeps running and scrollback is intact even when a tab is not visible.
 - **Multiple AI CLIs in one place** — designed to host tools like Claude Code, OpenCode, and other terminal-based AI assistants.
 - **Native desktop app** — built on Tauri v2 for a fast, lightweight shell around a modern web UI.
 - **Secure by default** — restrictive Content Security Policy and minimal Tauri capabilities out of the box. See [docs/security.md](docs/security.md).
+
+## UI Overview
+
+The app uses a three-part Mantine `AppShell`:
+
+- **Header** — app title and navbar toggle.
+- **Navbar (left sidebar)** — a "Cards" section with a `+` button to add cards. Each card is a `Tabs.Tab`; clicking it activates the corresponding terminal. A small `×` button on each tab removes the card and kills its PTY session.
+- **Main pane** — one `Tabs.Panel` per card, each containing an xterm.js terminal connected to a real shell via Tauri IPC. Inactive panels are hidden with CSS (`display: none`) but remain mounted, keeping their PTY sessions alive.
+
+When there are no cards, the main pane shows an empty-state prompt and the sidebar shows "No cards yet".
 
 ## Quick Start
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -40,6 +40,12 @@ The canvas stub returns a minimal `CanvasRenderingContext2D`-shaped object (all 
 
 `Terminal.test.tsx` mocks `@xterm/xterm` and `@xterm/addon-fit` at the module level with class spies rather than relying on a real renderer. xterm 5.x's DOM renderer requires layout APIs (`clientWidth`/`clientHeight`, canvas, WebGL) that jsdom does not provide, so assertions are made against the spies (e.g., `writeln`, `dispose`, `fit`) rather than against rendered terminal rows.
 
+`Terminal` requires a `sessionId` prop (a stable UUID supplied by the caller). Every `renderWithProviders(<Terminal />)` call in tests must pass an explicit `sessionId`, for example `renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />)`. Because `NavBar` renders `Tabs.Tab` and `Tabs.List`, tests for `NavBar` must wrap the component in a `<Tabs>` context — see `NavBar.test.tsx` for the pattern.
+
+### Testing appReducer directly
+
+`appReducer` is exported from `src/App.tsx` as a named export alongside `AppState`. This makes it testable in isolation as a pure function without rendering the `App` component at all. `App.test.tsx` contains a dedicated `describe("appReducer")` block that imports the reducer and `AppState` type directly and asserts on return values without any DOM involvement. When adding reducer logic, prefer adding a case to this describe block first (pure-function tests run faster and give clearer failure messages than component integration tests).
+
 ## E2E Tests (Playwright)
 
 Test files live in the top-level `e2e/` directory, separate from the unit tests in `src/`.
@@ -62,14 +68,25 @@ This downloads the Chromium browser binary. Without it, `pnpm test:e2e` will fai
 
 After `pnpm tauri dev` opens the app window, perform the following checks to confirm the real PTY integration is working end-to-end.
 
-1. **Basic shell interaction** — Type `pwd` and press Enter. Confirm the current working directory is printed (should be your home directory).
-2. **Shell identity** — Type `echo $SHELL` and press Enter. Confirm the output matches your default shell (e.g. `/bin/zsh` or `/bin/bash`).
-3. **Terminal type** — Type `echo $TERM` and press Enter. Confirm the output is `xterm-256color`.
-4. **PTY dimensions** — Type `stty size` and press Enter. Confirm the output matches the visible terminal dimensions (rows × cols). Resize the window and run `stty size` again to confirm the dimensions update.
-5. **Shell exit** — Type `exit` and press Enter. Confirm `[process exited]` appears in the terminal and the shell does not auto-respawn.
-6. **Orphan check** — First, _while the app is still running_, verify no zombie shell processes exist: `ps aux | grep -E "$(basename $SHELL).*defunct"` should return empty. Then close the app (or run `exit`) and confirm no lingering shell processes remain: `ps aux | grep -v grep | grep "$(basename $SHELL)"` should not show a process owned by the app.
-7. **Broken shell path** — In `src/components/Terminal/Terminal.tsx`, temporarily set the `pty_spawn` call to use an invalid shell path. Confirm the terminal displays `[failed to start shell: ...]` instead of crashing silently.
-8. **Binary paste** — Paste a chunk of text containing special characters (e.g. emoji, accented characters, or a long block of text). Confirm the characters arrive correctly in the shell without corruption or truncation.
+### Single-terminal checks
+
+1. **Empty state** — On launch, confirm the main pane shows the "No card selected" prompt and the sidebar shows "No cards yet".
+2. **Basic shell interaction** — Click `+` to add a card. Type `pwd` and press Enter. Confirm the current working directory is printed (should be your home directory).
+3. **Shell identity** — Type `echo $SHELL` and press Enter. Confirm the output matches your default shell (e.g. `/bin/zsh` or `/bin/bash`).
+4. **Terminal type** — Type `echo $TERM` and press Enter. Confirm the output is `xterm-256color`.
+5. **PTY dimensions** — Type `stty size` and press Enter. Confirm the output matches the visible terminal dimensions (rows × cols). Resize the window and run `stty size` again to confirm the dimensions update.
+6. **Shell exit** — Type `exit` and press Enter. Confirm `[process exited]` appears in the terminal and the shell does not auto-respawn.
+7. **Orphan check** — First, _while the app is still running_, verify no zombie shell processes exist: `ps aux | grep -E "$(basename $SHELL).*defunct"` should return empty. Then close the app (or run `exit`) and confirm no lingering shell processes remain: `ps aux | grep -v grep | grep "$(basename $SHELL)"` should not show a process owned by the app.
+8. **Broken shell path** — In `src/components/Terminal/Terminal.tsx`, temporarily set the `pty_spawn` call to use an invalid shell path. Confirm the terminal displays `[failed to start shell: ...]` instead of crashing silently.
+9. **Binary paste** — Paste a chunk of text containing special characters (e.g. emoji, accented characters, or a long block of text). Confirm the characters arrive correctly in the shell without corruption or truncation.
+
+### Multi-tab checks
+
+10. **Session preservation across tab switches** — Add two cards. In the first tab type a distinctive command (e.g. `echo hello-from-tab-1`). Click the second tab and type something different. Click the first tab again — the first terminal must still show its prior output with the cursor where it was left.
+11. **Terminal sizing on activation** — After switching back to a tab that was hidden, confirm the terminal fills the panel without shrinking or showing blank space. Run `stty size` to confirm the dimensions are correct.
+12. **Remove active tab** — With two cards, make the second card active. Click its `×` button. Confirm the first card becomes active automatically and its terminal is unaffected.
+13. **Remove non-active tab** — With two cards, make the first card active. Click the second card's `×` button. Confirm the first card remains active and its terminal session is unchanged.
+14. **Return to empty state** — Remove all cards one by one. Confirm the empty-state prompt reappears in the main pane and "No cards yet" appears in the sidebar.
 
 ## CI
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -4,14 +4,17 @@
 ai-dungeon/
 ├── src/              # React + TypeScript frontend
 │   ├── main.tsx      # Entry point — mounts MantineProvider, imports xterm CSS
-│   ├── App.tsx       # Root component — wrapped in AppLayout
+│   ├── App.tsx       # Root component — useReducer for cards + activeId; owns tab state
+│   ├── types/
+│   │   └── card.ts   # Card type ({ id: string })
 │   └── components/
 │       ├── Terminal/
-│       │   ├── Terminal.tsx   # xterm.js wrapper — live shell via PTY IPC, FitAddon, base64 I/O
+│       │   ├── Terminal.tsx   # xterm.js wrapper — accepts sessionId prop; PTY IPC, FitAddon, base64 I/O
 │       │   ├── index.ts       # Barrel export
 │       │   └── Terminal.test.tsx
 │       └── layout/
-│           ├── AppLayout.tsx  # AppShell layout (header, navbar, main)
+│           ├── AppLayout.tsx  # Mantine Tabs + AppShell — Tabs.List in navbar, Tabs.Panel per card in main
+│           ├── NavBar.tsx     # Sidebar — card list as Tabs.Tab items, Add/Remove controls
 │           └── index.ts       # Barrel export
 ├── src-tauri/        # Rust backend (Tauri)
 │   ├── src/

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -222,4 +222,27 @@ describe("App", () => {
     // Burger button still renders regardless of card state.
     expect(screen.getByRole("button", { name: "Toggle navigation" })).toBeInTheDocument();
   });
+
+  it("ignores onChange(null) from Mantine Tabs while cards exist (null-guard)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    // Add a card so there is an active tab.
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(1);
+    // The newly added card should be active.
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    // Simulate Mantine Tabs calling onChange(null) by finding the tablist and
+    // firing a custom onChange event. We do this by directly invoking the
+    // internal prop. Since we can't easily reach the Tabs root onChange, we
+    // verify the guard indirectly: clicking the already-active tab causes
+    // Mantine to call onChange(null), and the tab should remain selected.
+    await user.click(tabs[0]);
+
+    // The tab must remain selected — null must be ignored.
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "./test-utils/render";
 import { App } from "./App";
+import { invoke } from "@tauri-apps/api/core";
 
 // Mock xterm to avoid jsdom canvas/layout API issues
 vi.mock("@xterm/xterm", () => {
@@ -38,10 +39,32 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockImplementation(() => Promise.resolve(vi.fn())),
 }));
 
+type AnyMock = ReturnType<typeof vi.fn>;
+
 describe("App", () => {
-  it("renders the AppShell with terminal content", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (invoke as unknown as AnyMock).mockResolvedValue(undefined);
+
+    globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+    }) as unknown as typeof ResizeObserver;
+  });
+
+  it("renders the empty-state message when there are no cards, then shows a terminal after adding one", async () => {
+    const user = userEvent.setup();
     renderWithProviders(<App />);
+
+    // Initial state: no cards — empty state visible, no terminal.
+    expect(screen.getByTestId("main-empty-state")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-root")).toBeNull();
+
+    // Add a card — terminal should appear.
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
     expect(screen.getByTestId("terminal-root")).toBeInTheDocument();
+    // Empty state disappears once a card exists.
+    expect(screen.queryByTestId("main-empty-state")).toBeNull();
   });
 
   it("adds and removes a card via the navbar", async () => {
@@ -53,8 +76,150 @@ describe("App", () => {
     const removeButton = screen.getByRole("button", { name: /Remove card/i });
     expect(removeButton).toBeInTheDocument();
 
+    // After adding one card, exactly one terminal is mounted.
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(1);
+
     await user.click(removeButton);
 
     expect(screen.queryByRole("button", { name: /Remove card/i })).toBeNull();
+    // After removing the only card, no terminals remain in the DOM.
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(0);
+  });
+
+  it("keeps all terminals in the DOM when switching tabs (keepMounted)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    // Add two cards.
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    // Both terminals are mounted because keepMounted=true.
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(2);
+
+    // Click the second tab (the second card's tab).
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+
+    // The first tab was activated on first add (first add rule). Click the second.
+    await user.click(tabs[1]);
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+
+    // Both terminals still in DOM after tab switch (keepMounted proof).
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(2);
+
+    // Switch back to the first tab.
+    await user.click(tabs[0]);
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    // Still both mounted.
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(2);
+  });
+
+  it("moves the active tab to the previous card when the active (last) card is removed", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    // Add three cards: A (active), B, C.
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+
+    // Under the "first add becomes active" rule, tab[0] (A) is active.
+    // Click tab[2] (C) to make it active.
+    await user.click(tabs[2]);
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+
+    // Remove C (the active tab) — active should move to B (previous in list).
+    const removeButtons = screen.getAllByRole("button", { name: /Remove card/i });
+    await user.click(removeButtons[2]);
+
+    // Now two tabs remain; the last one (B, now at index 1) should be active.
+    const remainingTabs = screen.getAllByRole("tab");
+    expect(remainingTabs).toHaveLength(2);
+    expect(remainingTabs[1]).toHaveAttribute("aria-selected", "true");
+
+    // Remove B (active) — active moves to A (the only remaining card).
+    const removeButtons2 = screen.getAllByRole("button", { name: /Remove card/i });
+    await user.click(removeButtons2[1]);
+
+    const finalTabs = screen.getAllByRole("tab");
+    expect(finalTabs).toHaveLength(1);
+    expect(finalTabs[0]).toHaveAttribute("aria-selected", "true");
+
+    // Remove A — empty state returns.
+    const lastRemoveButton = screen.getByRole("button", { name: /Remove card/i });
+    await user.click(lastRemoveButton);
+
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(0);
+    expect(screen.getByTestId("main-empty-state")).toBeInTheDocument();
+  });
+
+  it("moves active tab to previous card when a non-last active card is removed (F-3)", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    // Add three cards A, B, C. A is active (first-add rule).
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    const tabs = screen.getAllByRole("tab");
+
+    // Activate B (index 1).
+    await user.click(tabs[1]);
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+
+    // Remove B — active should move to A (previous, index 0 in remaining [A, C]).
+    const removeButtons = screen.getAllByRole("button", { name: /Remove card/i });
+    await user.click(removeButtons[1]);
+
+    const remainingTabs = screen.getAllByRole("tab");
+    expect(remainingTabs).toHaveLength(2);
+    // A is at index 0 of remaining; it should now be active.
+    expect(remainingTabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("does NOT call pty_kill when switching tabs (PTY sessions preserved)", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    // Add two cards.
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card" }));
+
+    // Both spawns happen synchronously relative to user events. Drain the
+    // microtask queue to ensure any async IIFE cancelled-path activity (which
+    // could call pty_kill if a terminal unmounted during an in-flight spawn)
+    // has settled before we clear the call history.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Clear call history AFTER all async setup has settled. The assertion
+    // below is only about tab-switching behaviour (not spawn activity).
+    mockInvoke.mockClear();
+
+    const tabs = screen.getAllByRole("tab");
+
+    // Switch back and forth three times.
+    await user.click(tabs[1]);
+    await user.click(tabs[0]);
+    await user.click(tabs[1]);
+
+    // Assert pty_kill was never called during the tab-switching phase.
+    const killCalls = mockInvoke.mock.calls.filter((c: unknown[]) => c[0] === "pty_kill");
+    expect(killCalls).toHaveLength(0);
+
+    // Both terminals remain in DOM (keepMounted proof).
+    expect(screen.queryAllByTestId("terminal-root")).toHaveLength(2);
+  });
+
+  it("renders the AppShell with the burger toggle button", () => {
+    renderWithProviders(<App />);
+    // Burger button still renders regardless of card state.
+    expect(screen.getByRole("button", { name: "Toggle navigation" })).toBeInTheDocument();
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "./test-utils/render";
-import { App } from "./App";
+import { App, appReducer } from "./App";
 import { invoke } from "@tauri-apps/api/core";
 
 // Mock xterm to avoid jsdom canvas/layout API issues
@@ -244,5 +244,19 @@ describe("App", () => {
 
     // The tab must remain selected — null must be ignored.
     expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+});
+
+describe("appReducer", () => {
+  it("activate ignores null while cards exist", () => {
+    const card = { id: "test-uuid-1" };
+    const state = { cards: [card], activeId: "test-uuid-1" };
+    expect(appReducer(state, { type: "activate", id: null })).toBe(state); // referential equality
+  });
+
+  it("activate accepts null when no cards exist", () => {
+    const state = { cards: [], activeId: null };
+    const result = appReducer(state, { type: "activate", id: null });
+    expect(result).toEqual({ cards: [], activeId: null });
   });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "./test-utils/render";
 import { App, appReducer } from "./App";
+import type { AppState } from "./App";
 import { invoke } from "@tauri-apps/api/core";
 
 // Mock xterm to avoid jsdom canvas/layout API issues
@@ -250,12 +251,12 @@ describe("App", () => {
 describe("appReducer", () => {
   it("activate ignores null while cards exist", () => {
     const card = { id: "test-uuid-1" };
-    const state = { cards: [card], activeId: "test-uuid-1" };
+    const state: AppState = { cards: [card], activeId: "test-uuid-1" };
     expect(appReducer(state, { type: "activate", id: null })).toBe(state); // referential equality
   });
 
   it("activate accepts null when no cards exist", () => {
-    const state = { cards: [], activeId: null };
+    const state: AppState = { cards: [], activeId: null };
     const result = appReducer(state, { type: "activate", id: null });
     expect(result).toEqual({ cards: [], activeId: null });
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,9 +25,8 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return {
         // The new card is appended to the end of the list.
         cards: [...state.cards, newCard],
-        // When there is no active card (e.g. first add), activate the new card.
-        // Subsequent adds leave the active tab on whichever card is currently selected.
-        activeId: state.activeId ?? newCard.id,
+        // Always activate the newly added card — conventional UX for terminal apps.
+        activeId: newCard.id,
       };
     }
     case "remove": {
@@ -52,6 +51,9 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { cards: remaining, activeId: nextActiveId };
     }
     case "activate": {
+      if (action.id === null && state.cards.length > 0) {
+        return state; // ignore null while cards exist
+      }
       return { ...state, activeId: action.id };
     }
     default:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,92 @@
-import { useCallback, useState } from "react";
-import { Terminal } from "./components/Terminal";
+import { useCallback, useReducer } from "react";
 import { AppLayout } from "./components/layout";
 import type { Card } from "./types/card";
 
+// ── State shape ───────────────────────────────────────────────────────────────
+
+interface AppState {
+  cards: Card[];
+  activeId: string | null;
+}
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+
+type AppAction =
+  | { type: "add" }
+  | { type: "remove"; id: string }
+  | { type: "activate"; id: string | null };
+
+// ── Reducer ───────────────────────────────────────────────────────────────────
+
+function appReducer(state: AppState, action: AppAction): AppState {
+  switch (action.type) {
+    case "add": {
+      const newCard: Card = { id: globalThis.crypto.randomUUID() };
+      return {
+        // The new card is appended to the end of the list.
+        cards: [...state.cards, newCard],
+        // When there is no active card (e.g. first add), activate the new card.
+        // Subsequent adds leave the active tab on whichever card is currently selected.
+        activeId: state.activeId ?? newCard.id,
+      };
+    }
+    case "remove": {
+      const remaining = state.cards.filter((c) => c.id !== action.id);
+      let nextActiveId = state.activeId;
+
+      if (state.activeId === action.id) {
+        // Active card is being removed. Move to the previous card in the list,
+        // falling back to the new first card if the removed card was the first,
+        // or to null when no cards remain.
+        if (remaining.length === 0) {
+          nextActiveId = null;
+        } else {
+          const removedIndex = state.cards.findIndex((c) => c.id === action.id);
+          // Previous card: index - 1, clamped to 0 (the new first card) when
+          // the removed card was at index 0.
+          const prevIndex = Math.max(0, removedIndex - 1);
+          nextActiveId = remaining[prevIndex]?.id ?? null;
+        }
+      }
+
+      return { cards: remaining, activeId: nextActiveId };
+    }
+    case "activate": {
+      return { ...state, activeId: action.id };
+    }
+    default:
+      return state;
+  }
+}
+
+const initialState: AppState = { cards: [], activeId: null };
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export function App() {
-  const [cards, setCards] = useState<Card[]>([]);
+  const [state, dispatch] = useReducer(appReducer, initialState);
 
   const addCard = useCallback(() => {
-    setCards((prev) => [...prev, { id: globalThis.crypto.randomUUID() }]);
+    dispatch({ type: "add" });
   }, []);
 
   const removeCard = useCallback((id: string) => {
-    setCards((prev) => prev.filter((c) => c.id !== id));
+    dispatch({ type: "remove", id });
+  }, []);
+
+  // Mantine Tabs calls onChange with string | null; thread that through so the
+  // user can switch tabs by clicking them.
+  const setActiveId = useCallback((value: string | null) => {
+    dispatch({ type: "activate", id: value });
   }, []);
 
   return (
-    <AppLayout cards={cards} onAddCard={addCard} onRemoveCard={removeCard}>
-      <Terminal />
-    </AppLayout>
+    <AppLayout
+      cards={state.cards}
+      activeId={state.activeId}
+      onActiveIdChange={setActiveId}
+      onAddCard={addCard}
+      onRemoveCard={removeCard}
+    />
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ type AppAction =
 
 // ── Reducer ───────────────────────────────────────────────────────────────────
 
-function appReducer(state: AppState, action: AppAction): AppState {
+export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case "add": {
       const newCard: Card = { id: globalThis.crypto.randomUUID() };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import type { Card } from "./types/card";
 
 // ── State shape ───────────────────────────────────────────────────────────────
 
-interface AppState {
+export interface AppState {
   cards: Card[];
   activeId: string | null;
 }

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -95,15 +95,10 @@ describe("Terminal", () => {
         disconnect: vi.fn(),
       };
     }) as unknown as typeof ResizeObserver;
-
-    // Stable UUID for deterministic session ID matching.
-    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(
-      "00000000-0000-0000-0000-000000000001",
-    );
   });
 
   it("calls pty_spawn with sessionId, cols, and rows on mount", async () => {
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     // Allow the async IIFE to run.
     await vi.waitFor(() => {
@@ -116,7 +111,7 @@ describe("Terminal", () => {
   });
 
   it("calls listen for pty:output and pty:exit events after spawn", async () => {
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     await vi.waitFor(() => {
       const mockListen = listen as unknown as AnyMock;
@@ -127,7 +122,7 @@ describe("Terminal", () => {
   });
 
   it("registers onData handler and forwards input as base64 via pty_write", async () => {
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     // After the refactor, onData is registered synchronously at mount (before
     // fitAddon.fit()). Wait for it to have been registered.
@@ -159,7 +154,9 @@ describe("Terminal", () => {
   });
 
   it("disposes onData, calls unlistens, and invokes pty_kill on unmount", async () => {
-    const { unmount } = renderWithProviders(<Terminal />);
+    const { unmount } = renderWithProviders(
+      <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,
+    );
 
     // Wait for both listen() calls to have resolved and stored their spies.
     await vi.waitFor(() => {
@@ -187,7 +184,7 @@ describe("Terminal", () => {
     const mockInvoke = invoke as unknown as AnyMock;
     mockInvoke.mockRejectedValueOnce(new Error("shell not found"));
 
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     const termInstance = getTermInstance();
     await vi.waitFor(() => {
@@ -216,7 +213,9 @@ describe("Terminal", () => {
     // First invoke call is pty_spawn; subsequent calls (pty_kill) resolve immediately.
     mockInvoke.mockImplementationOnce(() => spawnPromise);
 
-    const { unmount } = renderWithProviders(<Terminal />);
+    const { unmount } = renderWithProviders(
+      <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,
+    );
 
     // Unmount before spawn resolves — cleanup fires pty_kill (no session yet).
     act(() => {
@@ -237,7 +236,7 @@ describe("Terminal", () => {
   });
 
   it("calls FitAddon.fit on initial mount", () => {
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
     const fitInstance = getFitInstance();
     expect(fitInstance.fit).toHaveBeenCalled();
   });
@@ -253,7 +252,7 @@ describe("Terminal", () => {
       };
     }) as unknown as typeof ResizeObserver;
 
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     // After the refactor, onData is registered synchronously (before spawn).
     // Wait for both listen() calls to resolve, which confirms isReadyRef.current
@@ -296,7 +295,7 @@ describe("Terminal", () => {
         }),
     );
 
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     // Give React a tick to mount and set up the observer.
     await new Promise((r) => setTimeout(r, 10));
@@ -316,7 +315,9 @@ describe("Terminal", () => {
   });
 
   it("disposes terminal and disconnects observer on unmount", async () => {
-    const { unmount } = renderWithProviders(<Terminal />);
+    const { unmount } = renderWithProviders(
+      <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,
+    );
 
     const termInstance = getTermInstance();
     const MockResizeObserver = globalThis.ResizeObserver as unknown as AnyMock;
@@ -343,7 +344,7 @@ describe("Terminal", () => {
     // First invoke call is pty_spawn; all subsequent calls resolve immediately.
     mockInvoke.mockImplementationOnce(() => spawnPromise);
 
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     // onData is now registered synchronously — wait for registration.
     await vi.waitFor(() => {
@@ -393,7 +394,9 @@ describe("Terminal", () => {
 
     mockInvoke.mockImplementationOnce(() => spawnPromise);
 
-    const { unmount } = renderWithProviders(<Terminal />);
+    const { unmount } = renderWithProviders(
+      <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,
+    );
 
     // Wait for synchronous onData registration.
     await vi.waitFor(() => {
@@ -429,7 +432,7 @@ describe("Terminal", () => {
   it("surfaces pty_write errors via term.writeln", async () => {
     const mockInvoke = invoke as unknown as AnyMock;
 
-    renderWithProviders(<Terminal />);
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
 
     // Wait for the PTY to be ready (both listen() calls resolved).
     const mockListen = listen as unknown as AnyMock;
@@ -471,7 +474,9 @@ describe("Terminal", () => {
 
     mockInvoke.mockImplementationOnce(() => spawnPromise);
 
-    const { unmount } = renderWithProviders(<Terminal />);
+    const { unmount } = renderWithProviders(
+      <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,
+    );
 
     // Wait for synchronous onData registration.
     await vi.waitFor(() => {

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -1,14 +1,18 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 
-export function Terminal() {
-  const containerRef = useRef<HTMLDivElement>(null);
+interface TerminalProps {
+  // The caller supplies a stable UUID that identifies this PTY session. The
+  // same sessionId across re-renders means the same shell; a different sessionId
+  // triggers a full unmount/re-spawn via the useEffect dependency array.
+  sessionId: string;
+}
 
-  // One stable session ID per Terminal mount lifetime.
-  const sessionId = useMemo(() => crypto.randomUUID(), []);
+export function Terminal({ sessionId }: TerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!containerRef.current) return;

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { AppShell, Burger, Group, Tabs, Title } from "@mantine/core";
+import { AppShell, Burger, Group, Tabs, Text, Title } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import type { Card } from "../../types/card";
 import { NavBar } from "./NavBar";
@@ -77,9 +77,9 @@ export function AppLayout({
         <AppShell.Main>
           {cards.length === 0 ? (
             // Empty state: no cards, no terminals.
-            <span data-testid="main-empty-state">
+            <Text data-testid="main-empty-state" c="dimmed">
               No card selected. Click + in the sidebar to add one.
-            </span>
+            </Text>
           ) : (
             cards.map((card) => (
               // flex: 1, minHeight: 0 rather than height: 100% because AppShell.Main

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,55 +1,98 @@
-import { AppShell, Burger, Group, Title } from "@mantine/core";
+import { AppShell, Burger, Group, Tabs, Title } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import type { ReactNode } from "react";
 import type { Card } from "../../types/card";
 import { NavBar } from "./NavBar";
+import { Terminal } from "../Terminal";
 
-// cards props are required; only consumer is App.tsx (YAGNI — make optional if a second consumer is added)
+// Only consumer is App.tsx. `children` has been removed — AppLayout renders
+// Tabs.Panel content (Terminal instances) directly so that Tabs.List (navbar)
+// and Tabs.Panel (main) share the same Tabs context.
 interface AppLayoutProps {
-  children: ReactNode;
   cards: Card[];
   onAddCard: () => void;
   onRemoveCard: (id: string) => void;
+  activeId: string | null;
+  onActiveIdChange: (value: string | null) => void;
 }
 
-export function AppLayout({ children, cards, onAddCard, onRemoveCard }: AppLayoutProps) {
+export function AppLayout({
+  cards,
+  onAddCard,
+  onRemoveCard,
+  activeId,
+  onActiveIdChange,
+}: AppLayoutProps) {
   const [opened, { toggle }] = useDisclosure(true);
 
   return (
-    <AppShell
-      header={{ height: 60 }}
-      navbar={{
-        width: 250,
-        breakpoint: 0,
-        collapsed: { desktop: !opened },
-      }}
-      padding="md"
-      styles={{
-        main: {
-          display: "flex",
-          flexDirection: "column",
-          height: "calc(100vh - var(--app-shell-header-height, 60px))",
-          // Required so AppShell.Main can flex-shrink within the AppShell flex
-          // column and not force the layout taller than the viewport. The
-          // Terminal div inside also has minHeight: 0 for the same reason at
-          // the next level of the flex chain — both are needed for height: 100%
-          // on the Terminal container to resolve to a definite non-zero value.
-          minHeight: 0,
-        },
-      }}
+    // Tabs wraps the entire AppShell so that Tabs.List (inside AppShell.Navbar)
+    // and Tabs.Panel (inside AppShell.Main) share one React context.
+    // keepMounted=true keeps inactive Tabs.Panel nodes in the DOM so PTY
+    // sessions are not destroyed when the user switches tabs.
+    // keepMountedMode="display-none" is required: the default 'activity' mode
+    // uses React 19's Activity component, which suppresses effects in hidden
+    // panels — that would prevent the Terminal useEffect from spawning a PTY
+    // session until the panel is first activated. display-none hides the panel
+    // purely via CSS while keeping all component effects running normally.
+    <Tabs
+      orientation="vertical"
+      keepMounted={true}
+      keepMountedMode="display-none"
+      value={activeId}
+      onChange={onActiveIdChange}
     >
-      <AppShell.Header>
-        <Group h="100%" px="md">
-          <Burger opened={opened} onClick={toggle} size="sm" aria-label="Toggle navigation" />
-          <Title order={3}>AI Dungeon</Title>
-        </Group>
-      </AppShell.Header>
+      <AppShell
+        header={{ height: 60 }}
+        navbar={{
+          width: 250,
+          breakpoint: 0,
+          collapsed: { desktop: !opened },
+        }}
+        padding="md"
+        styles={{
+          main: {
+            display: "flex",
+            flexDirection: "column",
+            height: "calc(100vh - var(--app-shell-header-height, 60px))",
+            // Required so AppShell.Main can flex-shrink within the AppShell flex
+            // column and not force the layout taller than the viewport. The
+            // Terminal div inside also has minHeight: 0 for the same reason at
+            // the next level of the flex chain — both are needed for height: 100%
+            // on the Terminal container to resolve to a definite non-zero value.
+            minHeight: 0,
+          },
+        }}
+      >
+        <AppShell.Header>
+          <Group h="100%" px="md">
+            <Burger opened={opened} onClick={toggle} size="sm" aria-label="Toggle navigation" />
+            <Title order={3}>AI Dungeon</Title>
+          </Group>
+        </AppShell.Header>
 
-      <AppShell.Navbar p="md">
-        <NavBar cards={cards} onAddCard={onAddCard} onRemoveCard={onRemoveCard} />
-      </AppShell.Navbar>
+        <AppShell.Navbar p="md">
+          <NavBar cards={cards} onAddCard={onAddCard} onRemoveCard={onRemoveCard} />
+        </AppShell.Navbar>
 
-      <AppShell.Main>{children}</AppShell.Main>
-    </AppShell>
+        <AppShell.Main>
+          {cards.length === 0 ? (
+            // Empty state: no cards, no terminals.
+            <span data-testid="main-empty-state">
+              No card selected. Click + in the sidebar to add one.
+            </span>
+          ) : (
+            cards.map((card) => (
+              // flex: 1, minHeight: 0 rather than height: 100% because AppShell.Main
+              // is already a flex column — flex children need flex: 1 to fill the
+              // available space, whereas height: 100% does not resolve reliably
+              // against a flex-column parent without an explicit definite height.
+              <Tabs.Panel key={card.id} value={card.id} style={{ flex: 1, minHeight: 0 }}>
+                <Terminal sessionId={card.id} />
+              </Tabs.Panel>
+            ))
+          )}
+        </AppShell.Main>
+      </AppShell>
+    </Tabs>
   );
 }

--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -1,19 +1,31 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
+import { Tabs } from "@mantine/core";
 import { renderWithProviders } from "../../test-utils/render";
 import { NavBar } from "./NavBar";
+import type { ReactElement } from "react";
+
+// NavBar now renders Tabs.List and Tabs.Tab which require a Tabs ancestor for
+// context. Wrap each render in a vertical Tabs container.
+function renderNavBar(ui: ReactElement) {
+  return renderWithProviders(
+    <Tabs value={null} onChange={() => {}} orientation="vertical">
+      {ui}
+    </Tabs>,
+  );
+}
 
 describe("NavBar", () => {
   it("renders empty state when no cards are provided", () => {
-    renderWithProviders(<NavBar cards={[]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />);
+    renderNavBar(<NavBar cards={[]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />);
 
     expect(screen.getByText("No cards yet")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Remove card/i })).toBeNull();
   });
 
   it("renders provided cards with remove buttons", () => {
-    renderWithProviders(
+    renderNavBar(
       <NavBar cards={[{ id: "a" }, { id: "b" }]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />,
     );
 
@@ -26,7 +38,7 @@ describe("NavBar", () => {
     const onRemoveCard = vi.fn();
     const user = userEvent.setup();
 
-    renderWithProviders(<NavBar cards={[]} onAddCard={onAddCard} onRemoveCard={onRemoveCard} />);
+    renderNavBar(<NavBar cards={[]} onAddCard={onAddCard} onRemoveCard={onRemoveCard} />);
 
     await user.click(screen.getByRole("button", { name: "Add card" }));
 
@@ -38,7 +50,7 @@ describe("NavBar", () => {
     const onRemoveCard = vi.fn();
     const user = userEvent.setup();
 
-    renderWithProviders(
+    renderNavBar(
       <NavBar cards={[{ id: "a" }, { id: "b" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />,
     );
 
@@ -46,5 +58,27 @@ describe("NavBar", () => {
 
     expect(onRemoveCard).toHaveBeenCalledTimes(1);
     expect(onRemoveCard).toHaveBeenCalledWith("a");
+  });
+
+  it("does NOT trigger the tab onChange when the close button is clicked (stopPropagation)", async () => {
+    // This test verifies that event.stopPropagation() on the CloseButton prevents
+    // the click from bubbling to the Tabs.Tab and activating it before removal.
+    // If stopPropagation() were removed, the onChange spy would be called when
+    // clicking the close button.
+    const onChange = vi.fn();
+    const onRemoveCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <Tabs value={null} onChange={onChange} orientation="vertical">
+        <NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />
+      </Tabs>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove card a" }));
+
+    // onRemoveCard fires once, but the Tabs onChange handler must NOT be called.
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -69,9 +69,7 @@ describe("NavBar", () => {
     const onRemoveCard = vi.fn();
     const user = userEvent.setup();
 
-    renderNavBar(
-      <NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />,
-    );
+    renderNavBar(<NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />);
 
     const closeButton = screen.getByRole("button", { name: "Remove card a" });
     closeButton.focus();
@@ -85,9 +83,7 @@ describe("NavBar", () => {
     const onRemoveCard = vi.fn();
     const user = userEvent.setup();
 
-    renderNavBar(
-      <NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />,
-    );
+    renderNavBar(<NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />);
 
     const closeButton = screen.getByRole("button", { name: "Remove card a" });
     closeButton.focus();

--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -26,11 +26,11 @@ describe("NavBar", () => {
 
   it("renders provided cards with remove buttons", () => {
     renderNavBar(
-      <NavBar cards={[{ id: "a" }, { id: "b" }]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />,
+      <NavBar cards={[{ id: "abcdefgh" }, { id: "12345678" }]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />,
     );
 
-    expect(screen.getByRole("button", { name: "Remove card a" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Remove card b" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove card abcdefgh" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove card 12345678" })).toBeInTheDocument();
   });
 
   it("calls onAddCard when the Add card button is clicked", async () => {
@@ -55,6 +55,22 @@ describe("NavBar", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Remove card a" }));
+
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+    expect(onRemoveCard).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onRemoveCard when Enter is pressed on the close button (keyboard a11y)", async () => {
+    const onRemoveCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderNavBar(
+      <NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />,
+    );
+
+    const closeButton = screen.getByRole("button", { name: "Remove card a" });
+    closeButton.focus();
+    await user.keyboard("{Enter}");
 
     expect(onRemoveCard).toHaveBeenCalledTimes(1);
     expect(onRemoveCard).toHaveBeenCalledWith("a");

--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -26,9 +26,14 @@ describe("NavBar", () => {
 
   it("renders provided cards with remove buttons", () => {
     renderNavBar(
-      <NavBar cards={[{ id: "abcdefgh" }, { id: "12345678" }]} onAddCard={vi.fn()} onRemoveCard={vi.fn()} />,
+      <NavBar
+        cards={[{ id: "abcdefgh-1234-5678-abcd-ef1234567890" }, { id: "12345678" }]}
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+      />,
     );
 
+    // Use a full UUID so slice(0, 8) is actually exercised
     expect(screen.getByRole("button", { name: "Remove card abcdefgh" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove card 12345678" })).toBeInTheDocument();
   });
@@ -71,6 +76,22 @@ describe("NavBar", () => {
     const closeButton = screen.getByRole("button", { name: "Remove card a" });
     closeButton.focus();
     await user.keyboard("{Enter}");
+
+    expect(onRemoveCard).toHaveBeenCalledTimes(1);
+    expect(onRemoveCard).toHaveBeenCalledWith("a");
+  });
+
+  it("calls onRemoveCard when Space is pressed on the close button (keyboard a11y)", async () => {
+    const onRemoveCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderNavBar(
+      <NavBar cards={[{ id: "a" }]} onAddCard={vi.fn()} onRemoveCard={onRemoveCard} />,
+    );
+
+    const closeButton = screen.getByRole("button", { name: "Remove card a" });
+    closeButton.focus();
+    await user.keyboard(" ");
 
     expect(onRemoveCard).toHaveBeenCalledTimes(1);
     expect(onRemoveCard).toHaveBeenCalledWith("a");

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -38,7 +38,7 @@ export function NavBar({ cards, onAddCard, onRemoveCard }: NavBarProps) {
                 <ActionIcon
                   component="div"
                   role="button"
-                  aria-label={`Remove card ${card.id}`}
+                  aria-label={`Remove card ${card.id.slice(0, 8)}`}
                   variant="subtle"
                   size="xs"
                   tabIndex={0}
@@ -47,6 +47,13 @@ export function NavBar({ cards, onAddCard, onRemoveCard }: NavBarProps) {
                     // briefly activate the deleted tab before the card is removed.
                     event.stopPropagation();
                     onRemoveCard(card.id);
+                  }}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onRemoveCard(card.id);
+                    }
                   }}
                 >
                   ×

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,12 +1,5 @@
-import {
-  ActionIcon,
-  Card as MantineCard,
-  CloseButton,
-  Group,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
+import type React from "react";
+import { ActionIcon, Group, Tabs, Text, Title } from "@mantine/core";
 import type { Card } from "../../types/card";
 
 interface NavBarProps {
@@ -30,20 +23,38 @@ export function NavBar({ cards, onAddCard, onRemoveCard }: NavBarProps) {
           No cards yet
         </Text>
       ) : (
-        <Stack gap="xs">
+        // Tabs.List orientation is inherited from the parent <Tabs orientation="vertical">.
+        // No explicit orientation prop is needed here.
+        <Tabs.List>
           {cards.map((card) => (
-            <MantineCard key={card.id}>
-              <Group justify="space-between">
-                <Text>Card {card.id.slice(0, 8)}</Text>
-                {/* TODO: switch to card.title once Card gains a human-readable title field */}
-                <CloseButton
+            <Tabs.Tab key={card.id} value={card.id}>
+              <Group justify="space-between" wrap="nowrap">
+                <Text size="sm">Card {card.id.slice(0, 8)}</Text>
+                {/* component="div" avoids nesting <button> inside <button>
+                    (Tabs.Tab renders as <button>; CloseButton also renders as
+                    <button> by default, which is invalid HTML). Using a div
+                    with role="button" keeps the accessible name and click
+                    behaviour while producing valid HTML. */}
+                <ActionIcon
+                  component="div"
+                  role="button"
                   aria-label={`Remove card ${card.id}`}
-                  onClick={() => onRemoveCard(card.id)}
-                />
+                  variant="subtle"
+                  size="xs"
+                  tabIndex={0}
+                  onClick={(event: React.MouseEvent) => {
+                    // Stop the click from bubbling to the Tabs.Tab, which would
+                    // briefly activate the deleted tab before the card is removed.
+                    event.stopPropagation();
+                    onRemoveCard(card.id);
+                  }}
+                >
+                  ×
+                </ActionIcon>
               </Group>
-            </MantineCard>
+            </Tabs.Tab>
           ))}
-        </Stack>
+        </Tabs.List>
       )}
     </>
   );


### PR DESCRIPTION
Each card in the sidebar is now a Tabs.Tab; switching cards shows the corresponding xterm.js terminal in the main pane. PTY sessions survive tab switches via keepMountedMode="display-none" — the shell keeps running and scrollback is intact even when a panel is hidden.

Active tab state is managed by a useReducer-based appReducer (exported for isolated unit testing). New cards are auto-activated on creation, and removing the active card automatically activates the nearest remaining card. When all cards are removed, the app returns to the empty-state prompt.