### PR TITLE
fix(layout): stretch AppShell inside Tabs flex row so terminal fills viewport width

### DIFF
--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -1,0 +1,58 @@
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    write: vi.fn(),
+    writeln: vi.fn(),
+    open: vi.fn(),
+    loadAddon: vi.fn(),
+    dispose: vi.fn(),
+    onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  })),
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: vi.fn(),
+    proposeDimensions: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+  })),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockImplementation(() => Promise.resolve(vi.fn())),
+}));
+
+import { renderWithProviders } from "../../test-utils/render";
+import { AppLayout } from "./AppLayout";
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })) as unknown as typeof ResizeObserver;
+  });
+
+  it("applies flex:1 and minWidth:0 to the AppShell root element", () => {
+    const { container } = renderWithProviders(
+      <AppLayout
+        cards={[]}
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        activeId={null}
+        onActiveIdChange={vi.fn()}
+      />,
+    );
+
+    // m_89ab340 is the stable CSS-module class Mantine assigns to the AppShell root div.
+    const appShellRoot = container.querySelector(".m_89ab340");
+    expect(appShellRoot).not.toBeNull();
+    // jsdom normalises `flex: 1` to the longhand `"1 1 0%"`.
+    expect((appShellRoot as HTMLElement).style.flex).not.toBe("");
+    expect((appShellRoot as HTMLElement).style.flexGrow).toBe("1");
+    expect((appShellRoot as HTMLElement).style.minWidth).toBe("0px");
+  });
+});

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -50,6 +50,11 @@ export function AppLayout({
         }}
         padding="md"
         styles={{
+          // <Tabs orientation="vertical"> renders as display:flex; flex-direction:row.
+          // <AppShell> is the sole flex child of that row and would otherwise size
+          // to its intrinsic content width. flex:1 makes it stretch to fill the row,
+          // and minWidth:0 permits horizontal shrinkage so contents can flex correctly.
+          root: { flex: 1, minWidth: 0 },
           main: {
             display: "flex",
             flexDirection: "column",


### PR DESCRIPTION
The terminal was squashed to the left on initial mount because `<AppShell>` — the sole flex child of Mantine's `<Tabs orientation="vertical">` row — had no `flex: 1` or `min-width: 0`. This adds both properties to the `styles.root` slot with an inline comment explaining the layout contract.

A Vitest + RTL regression guard (`AppLayout.test.tsx`) is included to prevent silent re-introduction of the bug.