### PR TITLE
feat(ui): add SessionCard with 6-property 3-row layout to NavBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AI coding assistants increasingly run as CLIs that hold long-lived, stateful ses
 The app uses a three-part Mantine `AppShell`:
 
 - **Header** — app title and navbar toggle.
-- **Navbar (left sidebar)** — a "Cards" section with a `+` button to add cards. Each card is a `Tabs.Tab`; clicking it activates the corresponding terminal. A small `×` button on each tab removes the card and kills its PTY session.
+- **Navbar (left sidebar)** — a "Cards" section with a `+` button to add cards. Each card is a `Tabs.Tab` whose label is rendered by the `SessionCard` component: a 3-row block showing the session slug, `repo:branch • path-tail`, and PR / Issue badges. Clicking the tab activates the corresponding terminal; the `×` button in the top-right of each card removes it and kills its PTY session.
 - **Main pane** — one `Tabs.Panel` per card, each containing an xterm.js terminal connected to a real shell via Tauri IPC. Inactive panels are hidden with CSS (`display: none`) but remain mounted, keeping their PTY sessions alive.
 
 When there are no cards, the main pane shows an empty-state prompt and the sidebar shows "No cards yet".

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,6 +42,8 @@ The canvas stub returns a minimal `CanvasRenderingContext2D`-shaped object (all 
 
 `Terminal` requires a `sessionId` prop (a stable UUID supplied by the caller). Every `renderWithProviders(<Terminal />)` call in tests must pass an explicit `sessionId`, for example `renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />)`. Because `NavBar` renders `Tabs.Tab` and `Tabs.List`, tests for `NavBar` must wrap the component in a `<Tabs>` context — see `NavBar.test.tsx` for the pattern.
 
+`SessionCard` is also rendered inside `Tabs.Tab` in production. Its tests therefore wrap each render in `<Tabs value={null} onChange={() => {}} orientation="vertical">` for the same reason. The `stopPropagation` test additionally supplies an `onChange` spy on the `<Tabs>` wrapper to assert that tab activation is not triggered when the close button is clicked — matching the equivalent test in `NavBar.test.tsx`.
+
 ### Testing appReducer directly
 
 `appReducer` is exported from `src/App.tsx` as a named export alongside `AppState`. This makes it testable in isolation as a pure function without rendering the `App` component at all. `App.test.tsx` contains a dedicated `describe("appReducer")` block that imports the reducer and `AppState` type directly and asserts on return values without any DOM involvement. When adding reducer logic, prefer adding a case to this describe block first (pure-function tests run faster and give clearer failure messages than component integration tests).

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -6,16 +6,20 @@ ai-dungeon/
 │   ├── main.tsx      # Entry point — mounts MantineProvider, imports xterm CSS
 │   ├── App.tsx       # Root component — useReducer for cards + activeId; owns tab state
 │   ├── types/
-│   │   └── card.ts   # Card type ({ id: string })
+│   │   ├── card.ts      # Card type ({ id: string })
+│   │   └── session.ts   # SessionMeta interface (slug, repo, branch, workingDirectory, prNumber, issueNumber)
 │   └── components/
 │       ├── Terminal/
 │       │   ├── Terminal.tsx   # xterm.js wrapper — accepts sessionId prop; PTY IPC, FitAddon, base64 I/O
 │       │   ├── index.ts       # Barrel export
 │       │   └── Terminal.test.tsx
 │       └── layout/
-│           ├── AppLayout.tsx  # Mantine Tabs + AppShell — Tabs.List in navbar, Tabs.Panel per card in main
-│           ├── NavBar.tsx     # Sidebar — card list as Tabs.Tab items, Add/Remove controls
-│           └── index.ts       # Barrel export
+│           ├── AppLayout.tsx          # Mantine Tabs + AppShell — Tabs.List in navbar, Tabs.Panel per card in main
+│           ├── NavBar.tsx             # Sidebar — card list as Tabs.Tab items, Add/Remove controls; renders SessionCard per tab
+│           ├── SessionCard.tsx        # 3-row tab label: slug + close button, repo:branch • path-tail, PR/Issue badges
+│           ├── SessionCard.test.tsx   # Unit tests for SessionCard (11 cases)
+│           ├── sessionMeta.mock.ts    # Deterministic mock SessionMeta fixtures keyed by card id
+│           └── index.ts              # Barrel export
 ├── src-tauri/        # Rust backend (Tauri)
 │   ├── src/
 │   │   ├── main.rs   # Binary entry point

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,6 +1,6 @@
-import type React from "react";
 import { ActionIcon, Group, Tabs, Text, Title } from "@mantine/core";
 import type { Card } from "../../types/card";
+import { SessionCard } from "./SessionCard";
 
 interface NavBarProps {
   cards: Card[];
@@ -28,37 +28,7 @@ export function NavBar({ cards, onAddCard, onRemoveCard }: NavBarProps) {
         <Tabs.List>
           {cards.map((card) => (
             <Tabs.Tab key={card.id} value={card.id}>
-              <Group justify="space-between" wrap="nowrap">
-                <Text size="sm">Card {card.id.slice(0, 8)}</Text>
-                {/* component="div" avoids nesting <button> inside <button>
-                    (Tabs.Tab renders as <button>; CloseButton also renders as
-                    <button> by default, which is invalid HTML). Using a div
-                    with role="button" keeps the accessible name and click
-                    behaviour while producing valid HTML. */}
-                <ActionIcon
-                  component="div"
-                  role="button"
-                  aria-label={`Remove card ${card.id.slice(0, 8)}`}
-                  variant="subtle"
-                  size="xs"
-                  tabIndex={0}
-                  onClick={(event: React.MouseEvent) => {
-                    // Stop the click from bubbling to the Tabs.Tab, which would
-                    // briefly activate the deleted tab before the card is removed.
-                    event.stopPropagation();
-                    onRemoveCard(card.id);
-                  }}
-                  onKeyDown={(e: React.KeyboardEvent) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onRemoveCard(card.id);
-                    }
-                  }}
-                >
-                  ×
-                </ActionIcon>
-              </Group>
+              <SessionCard cardId={card.id} onRemove={onRemoveCard} />
             </Tabs.Tab>
           ))}
         </Tabs.List>

--- a/src/components/layout/SessionCard.test.tsx
+++ b/src/components/layout/SessionCard.test.tsx
@@ -1,0 +1,155 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { Tabs } from "@mantine/core";
+import { renderWithProviders } from "../../test-utils/render";
+import { SessionCard } from "./SessionCard";
+import { getMockSessionMeta, SESSION_META_FIXTURES } from "./sessionMeta.mock";
+
+// Cards 1–5 are wrapped in Tabs context matching production rendering.
+function renderInTabs(cardId: string, onRemove = vi.fn()) {
+  return renderWithProviders(
+    <Tabs value={null} onChange={() => {}} orientation="vertical">
+      <Tabs.Tab value={cardId}>
+        <SessionCard cardId={cardId} onRemove={onRemove} />
+      </Tabs.Tab>
+    </Tabs>,
+  );
+}
+
+describe("SessionCard", () => {
+  // Use fixture 0 (slug: "refactor-auth-flow", repo: acme-corp/ai-dungeon,
+  // workingDirectory: "~/projects/ai-dungeon", prNumber: 42, issueNumber: 17)
+  // "d" = charCode 100; 100 % 4 = 0 → fixture 0
+  const CARD_ID_F0 = "d";
+
+  // Use fixture 1 (slug: "fix-terminal-resize", repo: acme-corp/backend-service,
+  // workingDirectory: "/home/user/work/backend-service/src/handlers",
+  // prNumber: 7, issueNumber: undefined)
+  // Need a cardId whose charCode sum % 4 === 1
+  // "b" = 98; 98 % 4 = 2. "e" = 101; 101 % 4 = 1. Use "e".
+  const CARD_ID_F1 = "e";
+
+  // Use fixture 2 (slug: "add-issue-tracker", issueNumber: 99, prNumber: undefined)
+  // "f" = 102; 102 % 4 = 2. Use "f".
+  const CARD_ID_F2 = "f";
+
+  // Use fixture 3 (slug: "chore-update-deps", prNumber: undefined, issueNumber: undefined)
+  // "g" = 103; 103 % 4 = 3. Use "g".
+  const CARD_ID_F3 = "g";
+
+  it("1. renders the slug from the mock fixture for the given cardId", () => {
+    renderInTabs(CARD_ID_F0);
+    expect(screen.getByText(SESSION_META_FIXTURES[0].slug)).toBeInTheDocument();
+  });
+
+  it("2. renders close button with correct aria-label and calls onRemove when clicked", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    renderInTabs("abcdefgh-1234-5678-abcd-ef1234567890", onRemove);
+
+    const btn = screen.getByRole("button", { name: "Remove card abcdefgh" });
+    expect(btn).toBeInTheDocument();
+
+    await user.click(btn);
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith("abcdefgh-1234-5678-abcd-ef1234567890");
+  });
+
+  it("3. calls onRemove when Enter is pressed on the close button", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    renderInTabs("a", onRemove);
+
+    const btn = screen.getByRole("button", { name: "Remove card a" });
+    btn.focus();
+    await user.keyboard("{Enter}");
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith("a");
+  });
+
+  it("4. calls onRemove when Space is pressed on the close button", async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    renderInTabs("a", onRemove);
+
+    const btn = screen.getByRole("button", { name: "Remove card a" });
+    btn.focus();
+    await user.keyboard(" ");
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith("a");
+  });
+
+  it("6. tooltip on repo name shows owner/name", async () => {
+    const user = userEvent.setup();
+    renderInTabs(CARD_ID_F0);
+
+    const meta = SESSION_META_FIXTURES[0];
+    const trigger = screen.getByText(meta.repo.name);
+    await user.hover(trigger);
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(`${meta.repo.owner}/${meta.repo.name}`);
+  });
+
+  it("7. tooltip on working-directory tail shows the full path", async () => {
+    const user = userEvent.setup();
+    // Use fixture 1: full path "/home/user/work/backend-service/src/handlers"
+    // visible tail: "src/handlers"
+    renderInTabs(CARD_ID_F1);
+
+    // The visible tail differs from the full path — hover the tail text
+    const trigger = screen.getByText("src/handlers");
+    await user.hover(trigger);
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(SESSION_META_FIXTURES[1].workingDirectory);
+  });
+
+  it("8. working-directory visible text is last 1-2 segments", () => {
+    // Fixture 1: "/home/user/work/backend-service/src/handlers" → "src/handlers"
+    renderInTabs(CARD_ID_F1);
+    expect(screen.getByText("src/handlers")).toBeInTheDocument();
+    expect(screen.queryByText(SESSION_META_FIXTURES[1].workingDirectory)).toBeNull();
+  });
+
+  it("9a. PR badge shows 'PR —' when prNumber is undefined", () => {
+    // Fixture 2 has no prNumber
+    renderInTabs(CARD_ID_F2);
+    expect(screen.getByText("PR —")).toBeInTheDocument();
+  });
+
+  it("9b. PR badge shows 'PR #n' when prNumber is defined", () => {
+    // Fixture 0 has prNumber: 42
+    renderInTabs(CARD_ID_F0);
+    expect(screen.getByText("PR #42")).toBeInTheDocument();
+  });
+
+  it("10a. Issue badge shows 'Issue —' when issueNumber is undefined", () => {
+    // Fixture 1 has no issueNumber
+    renderInTabs(CARD_ID_F1);
+    expect(screen.getByText("Issue —")).toBeInTheDocument();
+  });
+
+  it("10b. Issue badge shows '#n' when issueNumber is defined", () => {
+    // Fixture 0 has issueNumber: 17
+    renderInTabs(CARD_ID_F0);
+    expect(screen.getByText("#17")).toBeInTheDocument();
+  });
+
+  it("11. third placeholder badge with text '—' is always present", () => {
+    renderInTabs(CARD_ID_F3);
+    // Fixture 3 has neither PR nor Issue, so only the standalone '—' badge remains
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("mock module is deterministic: same cardId returns deeply equal objects", () => {
+    const id = "test-determinism-check";
+    const a = getMockSessionMeta(id);
+    const b = getMockSessionMeta(id);
+    expect(a).toEqual(b);
+  });
+});

--- a/src/components/layout/SessionCard.tsx
+++ b/src/components/layout/SessionCard.tsx
@@ -1,0 +1,97 @@
+import type React from "react";
+import { ActionIcon, Badge, Group, Stack, Text, Tooltip } from "@mantine/core";
+import { getMockSessionMeta } from "./sessionMeta.mock";
+
+interface SessionCardProps {
+  cardId: string;
+  onRemove: (id: string) => void;
+}
+
+/**
+ * Returns the last 1-2 path segments of a POSIX path (forward-slash only).
+ * Trailing slashes are stripped before splitting.
+ */
+function lastSegments(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  const parts = trimmed.split("/").filter(Boolean);
+  if (parts.length >= 2) {
+    return parts.slice(-2).join("/");
+  }
+  return parts[parts.length - 1] ?? "";
+}
+
+export function SessionCard({ cardId, onRemove }: SessionCardProps) {
+  const meta = getMockSessionMeta(cardId);
+
+  return (
+    <Stack gap="xs">
+      {/* Row 1: slug + close button */}
+      <Group justify="space-between" wrap="nowrap">
+        <Text size="sm" fw={700}>
+          {meta.slug}
+        </Text>
+        {/* component="div" avoids nesting <button> inside <button>
+            (Tabs.Tab renders as <button>; ActionIcon renders as <button> by default,
+            which is invalid HTML). Using a div with role="button" keeps the
+            accessible name and click behaviour while producing valid HTML. */}
+        <ActionIcon
+          component="div"
+          role="button"
+          aria-label={`Remove card ${cardId.slice(0, 8)}`}
+          variant="subtle"
+          size="xs"
+          tabIndex={0}
+          onClick={(event: React.MouseEvent) => {
+            event.stopPropagation();
+            onRemove(cardId);
+          }}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              e.stopPropagation();
+              onRemove(cardId);
+            }
+          }}
+        >
+          ×
+        </ActionIcon>
+      </Group>
+
+      {/* Row 2: repo : branch • path-tail */}
+      <Group gap="xs" wrap="nowrap">
+        <Tooltip label={`${meta.repo.owner}/${meta.repo.name}`} withinPortal={false}>
+          <Text size="xs" c="dimmed" truncate>
+            {meta.repo.name}
+          </Text>
+        </Tooltip>
+        <Text size="xs" c="dimmed">
+          :
+        </Text>
+        <Text size="xs" c="dimmed" truncate>
+          {meta.branch}
+        </Text>
+        <Text size="xs" c="dimmed">
+          •
+        </Text>
+        <Tooltip label={meta.workingDirectory} withinPortal={false}>
+          <Text size="xs" c="dimmed" truncate>
+            {lastSegments(meta.workingDirectory)}
+          </Text>
+        </Tooltip>
+      </Group>
+
+      {/* Row 3: PR badge, Issue badge, placeholder badge */}
+      <Group gap="xs" wrap="nowrap">
+        <Badge size="xs" variant="light">
+          {meta.prNumber ? `PR #${meta.prNumber}` : "PR —"}
+        </Badge>
+        <Badge size="xs" variant="light">
+          {meta.issueNumber ? `#${meta.issueNumber}` : "Issue —"}
+        </Badge>
+        <Badge size="xs" variant="light">
+          —
+        </Badge>
+      </Group>
+    </Stack>
+  );
+}

--- a/src/components/layout/sessionMeta.mock.ts
+++ b/src/components/layout/sessionMeta.mock.ts
@@ -1,0 +1,46 @@
+import type { SessionMeta } from "../../types/session";
+
+export const SESSION_META_FIXTURES: SessionMeta[] = [
+  {
+    slug: "refactor-auth-flow",
+    workingDirectory: "~/projects/ai-dungeon",
+    branch: "feat/session-card",
+    prNumber: 42,
+    issueNumber: 17,
+    repo: { owner: "acme-corp", name: "ai-dungeon" },
+  },
+  {
+    slug: "fix-terminal-resize",
+    workingDirectory: "/home/user/work/backend-service/src/handlers",
+    branch: "fix/terminal-resize",
+    prNumber: 7,
+    repo: { owner: "acme-corp", name: "backend-service" },
+  },
+  {
+    slug: "add-issue-tracker",
+    workingDirectory: "/Users/alex/code/frontend",
+    branch: "feat/issue-tracker",
+    issueNumber: 99,
+    repo: { owner: "open-source-org", name: "frontend" },
+  },
+  {
+    slug: "chore-update-deps",
+    workingDirectory: "~/personal/side-project",
+    branch: "chore/update-deps",
+    repo: { owner: "alkofu", name: "side-project" },
+  },
+];
+
+/**
+ * Returns a deterministic SessionMeta fixture for the given cardId.
+ * Uses a char-code sum mod fixtures.length mapping — note this introduces a
+ * cosmetic bias toward lower-indexed fixtures for sequential single-char IDs,
+ * which is acceptable for mock data.
+ */
+export function getMockSessionMeta(cardId: string): SessionMeta {
+  let sum = 0;
+  for (let i = 0; i < cardId.length; i++) {
+    sum += cardId.charCodeAt(i);
+  }
+  return SESSION_META_FIXTURES[sum % SESSION_META_FIXTURES.length];
+}

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -1,0 +1,11 @@
+export interface SessionMeta {
+  slug: string;
+  workingDirectory: string;
+  branch: string;
+  prNumber?: number;
+  issueNumber?: number;
+  repo: {
+    owner: string;
+    name: string;
+  };
+}


### PR DESCRIPTION
Replaces the plain single-line NavBar tab label with a rich SessionCard component. Each tab now shows three rows: (1) bold session slug + close button, (2) repo-name:branch • path-tail (with tooltips for full owner/repo and full path), (3) PR and Issue badges with — placeholders when absent. Session data comes from a deterministic mock module that is designed as a swap seam — follow-up PRs will replace it with real values sourced from the terminal session.