### PR TITLE
feat(ui): add github pr and issue icons to sessioncard badges

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -17,7 +17,7 @@ ai-dungeon/
 │           ├── AppLayout.tsx          # Mantine Tabs + AppShell — Tabs.List in navbar, Tabs.Panel per card in main
 │           ├── NavBar.tsx             # Sidebar — card list as Tabs.Tab items, Add/Remove controls; renders SessionCard per tab
 │           ├── SessionCard.tsx        # 3-row tab label: slug + close button, repo:branch • path-tail, PR/Issue badges
-│           ├── SessionCard.test.tsx   # Unit tests for SessionCard (11 cases)
+│           ├── SessionCard.test.tsx   # Unit tests for SessionCard (16 cases)
 │           ├── sessionMeta.mock.ts    # Deterministic mock SessionMeta fixtures keyed by card id
 │           └── index.ts              # Barrel export
 ├── src-tauri/        # Rust backend (Tauri)

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -5,6 +5,7 @@
 | Desktop shell   | [Tauri v2](https://v2.tauri.app/)                           |
 | Frontend        | React 19 + TypeScript                                       |
 | UI library      | [Mantine v9](https://mantine.dev/)                          |
+| Icons           | [@tabler/icons-react v3](https://tabler.io/icons)           |
 | Terminal        | [@xterm/xterm](https://xtermjs.org/) v5 + @xterm/addon-fit  |
 | Bundler         | Vite 8 (PostCSS via `postcss.config.cjs`)                   |
 | Package manager | pnpm                                                        |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@mantine/core": "^9.1.0",
     "@mantine/hooks": "^9.1.0",
+    "@tabler/icons-react": "^3.41.1",
     "@tauri-apps/api": "^2.10.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@mantine/hooks':
         specifier: ^9.1.0
         version: 9.1.0(react@19.2.5)
+      '@tabler/icons-react':
+        specifier: ^3.41.1
+        version: 3.41.1(react@19.2.5)
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
@@ -758,6 +761,14 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tabler/icons-react@3.41.1':
+    resolution: {integrity: sha512-kUgweE+DJtAlMZVIns1FTDdcbpRVnkK7ZpUOXmoxy3JAF0rSHj0TcP4VHF14+gMJGnF+psH2Zt26BLT6owetBA==}
+    peerDependencies:
+      react: '>= 16'
+
+  '@tabler/icons@3.41.1':
+    resolution: {integrity: sha512-OaRnVbRmH2nHtFeg+RmMJ/7m2oBIF9XCJAUD5gQnMrpK9f05ydj8MZrAf3NZQqOXyxGN1UBL0D5IKLLEUfr74Q==}
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -2026,6 +2037,13 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tabler/icons-react@3.41.1(react@19.2.5)':
+    dependencies:
+      '@tabler/icons': 3.41.1
+      react: 19.2.5
+
+  '@tabler/icons@3.41.1': {}
 
   '@tauri-apps/api@2.10.1': {}
 

--- a/src/components/layout/SessionCard.test.tsx
+++ b/src/components/layout/SessionCard.test.tsx
@@ -122,10 +122,22 @@ describe("SessionCard", () => {
     expect(screen.getByText("PR —")).toBeInTheDocument();
   });
 
+  it("9d. PR badge renders the pull-request icon when prNumber is undefined", () => {
+    // Fixture 2 has no prNumber — icon must still be present in the empty state
+    renderInTabs(CARD_ID_F2);
+    expect(screen.getByRole("img", { name: "Pull request" })).toBeInTheDocument();
+  });
+
   it("9b. PR badge shows 'PR #n' when prNumber is defined", () => {
     // Fixture 0 has prNumber: 42
     renderInTabs(CARD_ID_F0);
     expect(screen.getByText("PR #42")).toBeInTheDocument();
+  });
+
+  it("9c. PR badge renders the pull-request icon when prNumber is defined", () => {
+    // Fixture 0 has prNumber: 42
+    renderInTabs(CARD_ID_F0);
+    expect(screen.getByRole("img", { name: "Pull request" })).toBeInTheDocument();
   });
 
   it("10a. Issue badge shows 'Issue —' when issueNumber is undefined", () => {
@@ -134,16 +146,38 @@ describe("SessionCard", () => {
     expect(screen.getByText("Issue —")).toBeInTheDocument();
   });
 
+  it("10d. Issue badge renders the issue icon when issueNumber is undefined", () => {
+    // Fixture 1 has no issueNumber — icon must still be present in the empty state
+    renderInTabs(CARD_ID_F1);
+    expect(screen.getByRole("img", { name: "Issue" })).toBeInTheDocument();
+  });
+
   it("10b. Issue badge shows '#n' when issueNumber is defined", () => {
     // Fixture 0 has issueNumber: 17
     renderInTabs(CARD_ID_F0);
     expect(screen.getByText("#17")).toBeInTheDocument();
   });
 
+  it("10c. Issue badge renders the issue icon when issueNumber is defined", () => {
+    // Fixture 0 has issueNumber: 17
+    renderInTabs(CARD_ID_F0);
+    expect(screen.getByRole("img", { name: "Issue" })).toBeInTheDocument();
+  });
+
   it("11. third placeholder badge with text '—' is always present", () => {
     renderInTabs(CARD_ID_F3);
     // Fixture 3 has neither PR nor Issue, so only the standalone '—' badge remains
     expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("11b. placeholder badge renders no icon", () => {
+    // Fixture 3 has neither PR nor Issue
+    const { container } = renderInTabs(CARD_ID_F3);
+    const badges = container.querySelectorAll(".mantine-Badge-root");
+    expect(badges).toHaveLength(3);
+    const thirdBadge = badges[2];
+    expect(thirdBadge.querySelectorAll('[role="img"]')).toHaveLength(0);
+    expect(thirdBadge.textContent).toContain("—");
   });
 
   it("mock module is deterministic: same cardId returns deeply equal objects", () => {

--- a/src/components/layout/SessionCard.tsx
+++ b/src/components/layout/SessionCard.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { ActionIcon, Badge, Group, Stack, Text, Tooltip } from "@mantine/core";
+import { IconCircleDot, IconGitPullRequest } from "@tabler/icons-react";
 import { getMockSessionMeta } from "./sessionMeta.mock";
 
 interface SessionCardProps {
@@ -82,12 +83,21 @@ export function SessionCard({ cardId, onRemove }: SessionCardProps) {
 
       {/* Row 3: PR badge, Issue badge, placeholder badge */}
       <Group gap="xs" wrap="nowrap">
-        <Badge size="xs" variant="light">
+        <Badge
+          size="xs"
+          variant="light"
+          leftSection={<IconGitPullRequest size="1em" role="img" aria-label="Pull request" />}
+        >
           {meta.prNumber ? `PR #${meta.prNumber}` : "PR —"}
         </Badge>
-        <Badge size="xs" variant="light">
+        <Badge
+          size="xs"
+          variant="light"
+          leftSection={<IconCircleDot size="1em" role="img" aria-label="Issue" />}
+        >
           {meta.issueNumber ? `#${meta.issueNumber}` : "Issue —"}
         </Badge>
+        {/* No leftSection: placeholder badge intentionally renders no icon. */}
         <Badge size="xs" variant="light">
           —
         </Badge>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,5 +45,7 @@ export default defineConfig({
 
   optimizeDeps: {
     include: ["@xterm/xterm", "@xterm/addon-fit"],
+    // Workaround: @tabler/icons-react causes Vite dev-server chunk explosion (~23k pre-bundled chunks). Exclude from optimizeDeps. Production builds are unaffected.
+    exclude: ["@tabler/icons-react"],
   },
 });


### PR DESCRIPTION
Adds `IconGitPullRequest` and `IconCircleDot` icons from `@tabler/icons-react` to the PR and Issue badges in `SessionCard` Row 3, making the badge purpose immediately recognisable even when no PR/issue number is linked.

Icons render in both populated and empty states and carry `role="img"` with `aria-label` for screen-reader accessibility. Adds `optimizeDeps.exclude` for the icon library to avoid the known Vite dev-server chunk explosion with `@tabler/icons-react`.