### PR TITLE
fix(ui): constrain Tabs.Tab width to prevent SessionCard navbar overflow

### DIFF
--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -93,6 +93,44 @@ describe("NavBar", () => {
     expect(onRemoveCard).toHaveBeenCalledWith("a");
   });
 
+  // This test is a style-application guard, not a behavioural overflow test. The JSDOM test
+  // environment in `src/test-utils/setup.ts` does not import `@mantine/core/styles.css`, so
+  // `getComputedStyle` reflects only inline styles. The test verifies that the JSX statically
+  // applies the required style declarations; it cannot detect future regressions where overflow
+  // re-appears via a different mechanism (e.g., a child element whose own width pushes past the
+  // constraint).
+  //
+  // Behavioural validation (no horizontal overflow with realistic content) is performed manually
+  // in Step 4 and is the load-bearing safeguard. A future Playwright end-to-end test is recorded
+  // as a follow-up but is out of scope for this fix.
+  //
+  // The assertion that `w="100%"` resolves to inline `style={{ width: "100%" }}` is correct in
+  // Mantine v9 (verified by Truthhammer against the installed version) but the resolution chain
+  // is a Mantine implementation detail and could theoretically change in a future major version.
+  // If Mantine is upgraded across a major version boundary, re-verify this assertion.
+  it("applies width and overflow style declarations to Tabs.Tab so SessionCard does not overflow the navbar", () => {
+    renderNavBar(
+      <NavBar
+        cards={[{ id: "abcdefgh-1234-5678-abcd-ef1234567890" }]}
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+      />,
+    );
+
+    const tab = screen.getByRole("tab");
+
+    expect(tab).toHaveStyle({ overflow: "hidden" });
+    expect(tab).toHaveStyle({ whiteSpace: "normal" });
+    expect(tab).toHaveStyle({ display: "block" });
+    expect(tab).toHaveStyle({ width: "100%" });
+
+    const innerSpan = tab.querySelector(":scope > span");
+    expect(innerSpan).not.toBeNull();
+    expect(innerSpan).toHaveStyle({ width: "100%" });
+    expect(innerSpan).toHaveStyle({ textAlign: "left" });
+    expect(innerSpan).toHaveStyle({ whiteSpace: "normal" });
+  });
+
   it("does NOT trigger the tab onChange when the close button is clicked (stopPropagation)", async () => {
     // This test verifies that event.stopPropagation() on the CloseButton prevents
     // the click from bubbling to the Tabs.Tab and activating it before removal.

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -27,7 +27,26 @@ export function NavBar({ cards, onAddCard, onRemoveCard }: NavBarProps) {
         // No explicit orientation prop is needed here.
         <Tabs.List>
           {cards.map((card) => (
-            <Tabs.Tab key={card.id} value={card.id}>
+            // Mantine's `Tabs.Tab` button defaults to `display: flex; align-items: center;
+            // white-space: nowrap` with no width constraint, so it sizes to the intrinsic
+            // width of its children and overflows the 250 px navbar (verified at
+            // node_modules/@mantine/core/styles.css:7506-7516). The inner tabLabel span
+            // additionally carries `flex: 1; text-align: center` (styles.css:7541-7544),
+            // which would centre SessionCard content and defeat truncate. The props
+            // below override both layers:
+            //   w="100%"          - constrain outer button to navbar content width
+            //   style.overflow    - clip children that exceed the constrained width
+            //   style.whiteSpace  - allow the multi-row SessionCard Stack to wrap
+            //   style.display     - block layout makes the width constraint predictable
+            //                       (and renders the inner span's inherited `flex: 1` inert)
+            //   styles.tabLabel   - reset inner span: full width, left-aligned, wrappable
+            <Tabs.Tab
+              key={card.id}
+              value={card.id}
+              w="100%"
+              style={{ overflow: "hidden", whiteSpace: "normal", display: "block" }}
+              styles={{ tabLabel: { width: "100%", textAlign: "left", whiteSpace: "normal" } }}
+            >
               <SessionCard cardId={card.id} onRemove={onRemoveCard} />
             </Tabs.Tab>
           ))}


### PR DESCRIPTION
SessionCard content was bleeding onto the terminal pane because Mantine's Tabs.Tab button has no width constraint by default (display: flex; white-space: nowrap with no max-width). Adds w, style overflow/whiteSpace/display overrides on the outer button and styles.tabLabel overrides on the inner span so content stays inside the 250 px sidebar and truncate activates on long text.

Note: Step 4 (manual visual validation in the running Tauri app) is pending — a screenshot showing no navbar overflow with 3+ cards must be attached to this PR before merging.