### PR TITLE
fix(terminal): eliminate pty write failed race on card 2+ remount

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -122,10 +122,10 @@ Tests that exercise the PTY commands (`pty_spawn`, `pty_write`, `pty_resize`, `p
 
 The existing unit tests cover the map/generation layer without spawning a real shell:
 
-| Test | What it covers |
-| ---- | -------------- |
-| `pty_spawn_rejects_duplicate_session_id` | `try_reserve_session_id` returns `Err("session already exists: …")` on a duplicate sid and leaves the original reservation intact |
-| `pty_kill_with_stale_generation_is_noop` | `pty_kill` with an old generation token is a no-op; the session at the newer generation survives |
-| `pty_kill_with_matching_generation_removes_session` | `pty_kill` with the matching generation removes the session |
-| `pty_kill_with_none_generation_removes_session` | `pty_kill` with `None` removes the session unconditionally |
+| Test                                                | What it covers                                                                                                                                         |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pty_spawn_rejects_duplicate_session_id`            | `try_reserve_session_id` returns `Err("session already exists: …")` on a duplicate sid and leaves the original reservation intact                      |
+| `pty_kill_with_stale_generation_is_noop`            | `pty_kill` with an old generation token is a no-op; the session at the newer generation survives                                                       |
+| `pty_kill_with_matching_generation_removes_session` | `pty_kill` with the matching generation removes the session                                                                                            |
+| `pty_kill_with_none_generation_removes_session`     | `pty_kill` with `None` removes the session unconditionally                                                                                             |
 | `pty_kill_command_accepts_missing_generation_field` | serde deserialises a JSON payload missing the `generation` key as `generation: None` (necessary — not sufficient — signal for Tauri IPC compatibility) |

--- a/TESTING.md
+++ b/TESTING.md
@@ -78,7 +78,7 @@ After `pnpm tauri dev` opens the app window, perform the following checks to con
 4. **Terminal type** — Type `echo $TERM` and press Enter. Confirm the output is `xterm-256color`.
 5. **PTY dimensions** — Type `stty size` and press Enter. Confirm the output matches the visible terminal dimensions (rows × cols). Resize the window and run `stty size` again to confirm the dimensions update.
 6. **Shell exit** — Type `exit` and press Enter. Confirm `[process exited]` appears in the terminal and the shell does not auto-respawn.
-7. **Orphan check** — First, _while the app is still running_, verify no zombie shell processes exist: `ps aux | grep -E "$(basename $SHELL).*defunct"` should return empty. Then close the app (or run `exit`) and confirm no lingering shell processes remain: `ps aux | grep -v grep | grep "$(basename $SHELL)"` should not show a process owned by the app.
+7. **Orphan check** — Use a ppid-filtered approach to avoid conflating the user's interactive shells with app-spawned ones. Find the Tauri process pid: `APP_PID=$(pgrep -f 'ai-dungeon' | head -1)`. Then list shells whose parent is the app: `pgrep -P "$APP_PID" | xargs -I{} ps -p {} -o pid,ppid,command 2>/dev/null`. The output should be empty (no live cards) or list exactly the shells for the currently-open cards — no extras.
 8. **Broken shell path** — In `src/components/Terminal/Terminal.tsx`, temporarily set the `pty_spawn` call to use an invalid shell path. Confirm the terminal displays `[failed to start shell: ...]` instead of crashing silently.
 9. **Binary paste** — Paste a chunk of text containing special characters (e.g. emoji, accented characters, or a long block of text). Confirm the characters arrive correctly in the shell without corruption or truncation.
 
@@ -89,6 +89,8 @@ After `pnpm tauri dev` opens the app window, perform the following checks to con
 12. **Remove active tab** — With two cards, make the second card active. Click its `×` button. Confirm the first card becomes active automatically and its terminal is unaffected.
 13. **Remove non-active tab** — With two cards, make the first card active. Click the second card's `×` button. Confirm the first card remains active and its terminal session is unchanged.
 14. **Return to empty state** — Remove all cards one by one. Confirm the empty-state prompt reappears in the main pane and "No cards yet" appears in the sidebar.
+15. **No spurious errors on cards 2+** — Click `+` three times to create cards 2, 3, and 4. Inspect every terminal pane. No pane must display `[pty write failed: session not found: …]` or `[failed to start shell: session already exists]` on initial render. Type a command (e.g. `echo ok`) in each terminal and confirm it produces output.
+16. **No orphaned shells after rapid add/remove** — Rapidly add five cards, then remove all of them, then add five again. Run the ppid-filtered orphan check from step 7. The shell count must equal the number of currently-live cards exactly. Any excess indicates orphaned processes — treat as a regression and do not merge.
 
 ## CI
 
@@ -108,6 +110,22 @@ After `pnpm tauri dev` opens the app window, perform the following checks to con
 6. **Context persists across tab switches** — Switch between tabs back and forth. Confirm the status bar values for each card are preserved across switches (keepMounted proof).
 7. **Hook removal resilience** — In a single session, run `unset PROMPT_COMMAND; precmd_functions=()` (or the equivalent for your shell) to disable the hook. Confirm the status bar stops updating but does not crash. Close and reopen the card — confirm the hook is re-injected on the new PTY and the status bar starts updating again.
 
-## Rust Tests (Future Work)
+## Rust Tests
 
-The Rust backend (`src-tauri/`) exposes four PTY commands — `pty_spawn`, `pty_write`, `pty_resize`, and `pty_kill` — implemented in `src-tauri/src/pty.rs`. Unit tests for these commands require a real PTY device, which is unavailable in most CI environments and non-trivial to mock at the `portable-pty` trait boundary. Rust unit tests for the PTY layer are therefore deferred as future work. When added, they will use standard `#[cfg(test)]` modules and `cargo test`. No additional Rust test dependencies are anticipated.
+The Rust backend (`src-tauri/`) is tested with standard `#[cfg(test)]` modules and `cargo test`.
+
+```
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Tests that exercise the PTY commands (`pty_spawn`, `pty_write`, `pty_resize`, `pty_kill`) at the real PTY device boundary are deferred as future work — a real PTY is unavailable in most CI environments and non-trivial to mock at the `portable-pty` trait boundary.
+
+The existing unit tests cover the map/generation layer without spawning a real shell:
+
+| Test | What it covers |
+| ---- | -------------- |
+| `pty_spawn_rejects_duplicate_session_id` | `try_reserve_session_id` returns `Err("session already exists: …")` on a duplicate sid and leaves the original reservation intact |
+| `pty_kill_with_stale_generation_is_noop` | `pty_kill` with an old generation token is a no-op; the session at the newer generation survives |
+| `pty_kill_with_matching_generation_removes_session` | `pty_kill` with the matching generation removes the session |
+| `pty_kill_with_none_generation_removes_session` | `pty_kill` with `None` removes the session unconditionally |
+| `pty_kill_command_accepts_missing_generation_field` | serde deserialises a JSON payload missing the `generation` key as `generation: None` (necessary — not sufficient — signal for Tauri IPC compatibility) |

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -10,7 +10,7 @@ ai-dungeon/
 │   │   └── session.ts   # SessionMeta interface (slug, repo, branch, workingDirectory, prNumber, issueNumber)
 │   └── components/
 │       ├── Terminal/
-│       │   ├── Terminal.tsx   # xterm.js wrapper — accepts sessionId prop; PTY IPC, FitAddon, base64 I/O
+│       │   ├── Terminal.tsx   # xterm.js wrapper — accepts sessionId prop; PTY IPC, FitAddon, base64 I/O; module-level per-sid spawn-chain serialises pty_spawn/pty_kill to prevent StrictMode remount races
 │       │   ├── index.ts       # Barrel export
 │       │   └── Terminal.test.tsx
 │       └── layout/
@@ -24,7 +24,7 @@ ai-dungeon/
 │   ├── src/
 │   │   ├── main.rs   # Binary entry point
 │   │   ├── lib.rs    # Library crate (command handlers)
-│   │   └── pty.rs    # PTY session management (spawn/write/resize/kill commands)
+│   │   └── pty.rs    # PTY session management (spawn/write/resize/kill commands); generation tokens + duplicate-ID rejection prevent orphaned sessions on rapid remount
 │   ├── capabilities/ # Tauri permission grants
 │   ├── icons/        # App icons (all sizes)
 │   ├── Cargo.toml

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io::{Read, Write},
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
 };
@@ -69,28 +69,97 @@ const SHELL_INIT_POLYGLOT: &str = concat!(
 
 // ── Session ──────────────────────────────────────────────────────────────────
 
+/// Distinguishes a reserved-but-not-yet-spawned session from a fully active one.
+///
+/// A `Reserved` entry is inserted by `try_reserve_session_id` before any I/O
+/// so that duplicate `pty_spawn` calls for the same `session_id` are rejected
+/// immediately (before `openpty` is called). Once all I/O succeeds, the entry
+/// is replaced with `Active(...)`.
+///
+/// `pty_write` and `pty_resize` against a `Reserved` entry return a meaningful
+/// error rather than panicking.
+pub enum PtySessionState {
+    /// Slot is claimed; the PTY and shell have not been spawned yet.
+    Reserved,
+    /// PTY and shell are fully initialised and accepting I/O.
+    Active {
+        /// The master side of the PTY pair, used for resize.
+        master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
+        /// The write half of the PTY master, used for input.
+        ///
+        /// Held behind its own mutex so blocking writes never hold the outer map
+        /// lock while `pty_resize` tries to acquire `master`.
+        writer: Arc<Mutex<Box<dyn Write + Send>>>,
+        /// The spawned child process.
+        ///
+        /// NOTE: `Box<dyn portable_pty::Child + Send>` — `+ Sync` is NOT required
+        /// and WILL fail to compile. Do not add `+ Sync` here.
+        child: Arc<Mutex<Box<dyn portable_pty::Child + Send>>>,
+    },
+}
+
 pub struct PtySession {
-    /// The master side of the PTY pair, used for resize.
-    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
-    /// The write half of the PTY master, used for input.
-    ///
-    /// Held behind its own mutex so blocking writes never hold the outer map
-    /// lock while `pty_resize` tries to acquire `master`.
-    writer: Arc<Mutex<Box<dyn Write + Send>>>,
-    /// The spawned child process.
-    ///
-    /// NOTE: `Box<dyn portable_pty::Child + Send>` — `+ Sync` is NOT required
-    /// and WILL fail to compile. Do not add `+ Sync` here.
-    child: Arc<Mutex<Box<dyn portable_pty::Child + Send>>>,
+    /// Session lifecycle state — `Reserved` until I/O completes, then `Active`.
+    pub state: PtySessionState,
     /// Set to `true` by `pty_kill` before resources are dropped. The reader
     /// loop checks this flag after each `read()` to decide whether to continue.
-    shutdown: Arc<AtomicBool>,
+    pub shutdown: Arc<AtomicBool>,
+    /// Monotonic generation token assigned at reservation time. Increments with
+    /// every successful `pty_spawn`. `pty_kill` uses this to scope kills to the
+    /// intended session — a stale generation causes the kill to be a no-op.
+    pub generation: u64,
 }
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
+/// Holds all live (and reserved) PTY sessions plus a per-process generation counter.
+///
+/// # Design constraints (Ruinor F-7)
+/// `next_generation` is a separate `AtomicU64` — the existing map `Mutex` is
+/// NOT widened to `Mutex<(HashMap, u64)>`. This keeps the critical section
+/// around the map as narrow as possible.
 #[derive(Default)]
-pub struct PtyState(pub Mutex<HashMap<String, Arc<PtySession>>>);
+pub struct PtyState {
+    /// Map from session UUID to live session.
+    pub map: Mutex<HashMap<String, Arc<PtySession>>>,
+    /// Monotonic counter for generation tokens. Starts at `0`; actual sessions
+    /// receive `fetch_add(1, Relaxed) + 1` so generations begin at `1`, never `0`.
+    /// `0` is reserved as a sentinel meaning "unconditional kill".
+    pub next_generation: AtomicU64,
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+/// Reserve a `session_id` slot in the map **before** any I/O.
+///
+/// Returns `Ok(generation)` when the slot is free; inserts a `Reserved`
+/// placeholder and returns the new generation token. Returns
+/// `Err("session already exists: …")` when the sid is already present — the
+/// map is left unchanged. No I/O is performed under the lock.
+///
+/// `pty_spawn` calls this as its **first** action so that duplicate-spawn
+/// detection is cheap and requires no shell process to have been started.
+fn try_reserve_session_id(state: &PtyState, session_id: &str) -> Result<u64, String> {
+    let mut map = state.map.lock().map_err(|_| "state mutex poisoned".to_string())?;
+
+    if map.contains_key(session_id) {
+        return Err(format!("session already exists: {session_id}"));
+    }
+
+    // First-generation invariant (Ruinor F-C): fetch_add returns the pre-increment
+    // value. Adding 1 ensures the first session gets generation 1, not 0, so the
+    // sentinel value (0 = unconditional kill) is never collided with.
+    let generation = state.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
+
+    let placeholder = Arc::new(PtySession {
+        state: PtySessionState::Reserved,
+        shutdown: Arc::new(AtomicBool::new(false)),
+        generation,
+    });
+    map.insert(session_id.to_string(), placeholder);
+
+    Ok(generation)
+}
 
 // ── Commands ──────────────────────────────────────────────────────────────────
 
@@ -98,6 +167,13 @@ pub struct PtyState(pub Mutex<HashMap<String, Arc<PtySession>>>);
 /// to the frontend via `pty:output:{session_id}` events.
 ///
 /// `session_id` is generated by the frontend (UUID) and must be unique per tab.
+/// Returns the generation token (`u64`) on success so the frontend can scope
+/// subsequent `pty_kill` calls to this exact mount.
+///
+/// Returns `Err("session already exists: …")` if a session with the same
+/// `session_id` is already present in the map — a defensive guard against
+/// frontend bugs; the per-sid spawn-chain in Terminal.tsx should make this
+/// unreachable in normal operation.
 #[tauri::command]
 pub async fn pty_spawn(
     app: AppHandle,
@@ -105,139 +181,140 @@ pub async fn pty_spawn(
     session_id: String,
     cols: u16,
     rows: u16,
-) -> Result<(), String> {
-    let pty_system = NativePtySystem::default();
+) -> Result<u64, String> {
+    // ── Step 1: reserve the slot BEFORE any I/O ───────────────────────────────
+    // On duplicate sid: return Err immediately — no shell spawned, nothing to clean up.
+    let generation = try_reserve_session_id(&state, &session_id)?;
 
-    let size = PtySize {
-        rows,
-        cols,
-        pixel_width: 0,
-        pixel_height: 0,
-    };
+    // ── Step 2: all I/O; on any failure, free the reservation ─────────────────
+    let result = (|| -> Result<(Arc<Mutex<Box<dyn MasterPty + Send>>>, Box<dyn Write + Send>, Box<dyn portable_pty::Child + Send>, Box<dyn Read + Send>), String> {
+        let pty_system = NativePtySystem::default();
 
-    let pair = pty_system
-        .openpty(size)
-        .map_err(|e| format!("openpty failed: {e}"))?;
+        let size = PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
 
-    // Resolve the default shell.
-    #[cfg(unix)]
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
-    #[cfg(windows)]
-    let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".into());
+        let pair = pty_system
+            .openpty(size)
+            .map_err(|e| format!("openpty failed: {e}"))?;
 
-    let mut cmd = CommandBuilder::new(&shell);
-    cmd.env("TERM", "xterm-256color");
-    cmd.env("COLORTERM", "truecolor");
+        // Resolve the default shell.
+        #[cfg(unix)]
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
+        #[cfg(windows)]
+        let shell = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".into());
 
-    // Use HOME (Unix) / USERPROFILE (Windows) as the initial working directory.
-    #[cfg(unix)]
-    if let Ok(home) = std::env::var("HOME") {
-        cmd.cwd(home);
-    }
-    #[cfg(windows)]
-    if let Ok(profile) = std::env::var("USERPROFILE") {
-        cmd.cwd(profile);
-    }
+        let mut cmd = CommandBuilder::new(&shell);
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
 
-    // M-1: Take the writer from the BARE master FIRST, before wrapping master
-    // in Arc<Mutex<>>. The writer borrow requires exclusive access to the pair
-    // slot; wrapping first would move master before we can call take_writer().
-    let writer = pair
-        .master
-        .take_writer()
-        .map_err(|e| format!("take_writer failed: {e}"))?;
+        // Use HOME (Unix) / USERPROFILE (Windows) as the initial working directory.
+        #[cfg(unix)]
+        if let Ok(home) = std::env::var("HOME") {
+            cmd.cwd(home);
+        }
+        #[cfg(windows)]
+        if let Ok(profile) = std::env::var("USERPROFILE") {
+            cmd.cwd(profile);
+        }
 
-    // Now wrap master in Arc<Mutex<>> for shared resize access.
-    let master = Arc::new(Mutex::new(pair.master));
+        // M-1: Take the writer from the BARE master FIRST, before wrapping master
+        // in Arc<Mutex<>>. The writer borrow requires exclusive access to the pair
+        // slot; wrapping first would move master before we can call take_writer().
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| format!("take_writer failed: {e}"))?;
 
-    let child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| format!("spawn failed: {e}"))?;
+        // Now wrap master in Arc<Mutex<>> for shared resize access.
+        let master = Arc::new(Mutex::new(pair.master));
 
-    let shutdown = Arc::new(AtomicBool::new(false));
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| format!("spawn failed: {e}"))?;
 
-    // M-3: Clone the reader on the calling thread BEFORE inserting the session
-    // into the HashMap. If try_clone_reader fails we return Err cleanly without
-    // leaking a half-initialised session entry.
-    let reader = master
-        .lock()
-        .map_err(|_| "master mutex poisoned".to_string())?
-        .try_clone_reader()
-        .map_err(|e| format!("failed to clone reader: {e}"))?;
+        // M-3: Clone the reader on the calling thread BEFORE inserting the session
+        // into the HashMap. If try_clone_reader fails we return Err cleanly without
+        // leaking a half-initialised session entry.
+        let reader = master
+            .lock()
+            .map_err(|_| "master mutex poisoned".to_string())?
+            .try_clone_reader()
+            .map_err(|e| format!("failed to clone reader: {e}"))?;
 
-    let session = Arc::new(PtySession {
-        master,
-        writer: Arc::new(Mutex::new(writer)),
-        child: Arc::new(Mutex::new(child)),
-        shutdown: Arc::clone(&shutdown),
-    });
+        Ok((master, writer, child, reader))
+    })();
 
-    // Insert session; release the outer lock before spawning the reader task.
-    state
-        .0
-        .lock()
-        .map_err(|_| "state mutex poisoned".to_string())?
-        .insert(session_id.clone(), Arc::clone(&session));
+    match result {
+        Err(e) => {
+            // I/O failed — free the reservation so the sid can be retried.
+            if let Ok(mut map) = state.map.lock() {
+                map.remove(&session_id);
+            }
+            return Err(e);
+        }
+        Ok((master, writer, child, reader)) => {
+            let shutdown = Arc::new(AtomicBool::new(false));
 
-    // Inject the shell init polyglot on Unix so bash/zsh emit OSC 7 (CWD) and
-    // OSC 7337 (git context) after every prompt cycle. The bytes are written
-    // after session insertion so cleanup (pty_kill) can always find the session.
-    // On error we log and proceed — failure to inject does not abort pty_spawn;
-    // the terminal still works, just without OSC context updates.
-    #[cfg(unix)]
-    {
-        match session.writer.lock() {
-            Ok(mut w) => {
-                if let Err(e) = w
-                    .write_all(SHELL_INIT_POLYGLOT.as_bytes())
-                    .and_then(|_| w.flush())
-                {
-                    eprintln!("[ai-dungeon] shell init injection failed: {e}");
+            // Replace the Reserved placeholder with the fully-constructed Active session.
+            let session = Arc::new(PtySession {
+                state: PtySessionState::Active {
+                    master: Arc::clone(&master),
+                    writer: Arc::new(Mutex::new(writer)),
+                    child: Arc::new(Mutex::new(child)),
+                },
+                shutdown: Arc::clone(&shutdown),
+                generation,
+            });
+
+            state
+                .map
+                .lock()
+                .map_err(|_| "state mutex poisoned".to_string())?
+                .insert(session_id.clone(), session);
+
+            // Spawn a blocking thread for the PTY read loop. The reader holds an
+            // independent cloned handle — the master mutex remains free for
+            // pty_resize to acquire without waiting on a blocked read(). (M-2)
+            let app_clone = app.clone();
+            let sid = session_id.clone();
+            let shutdown_clone = Arc::clone(&shutdown);
+
+            tauri::async_runtime::spawn_blocking(move || {
+                let mut buf = [0u8; 4096];
+                let mut reader = reader;
+
+                loop {
+                    match reader.read(&mut buf) {
+                        Ok(0) => {
+                            // EOF — shell exited.
+                            let _ = app_clone.emit(&format!("pty:exit:{sid}"), ());
+                            break;
+                        }
+                        Ok(n) => {
+                            if shutdown_clone.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            let encoded = B64.encode(&buf[..n]);
+                            let _ = app_clone.emit(&format!("pty:output:{sid}"), encoded);
+                        }
+                        Err(_) => {
+                            if !shutdown_clone.load(Ordering::Relaxed) {
+                                let _ = app_clone.emit(&format!("pty:exit:{sid}"), ());
+                            }
+                            break;
+                        }
+                    }
                 }
-            }
-            Err(_) => {
-                eprintln!("[ai-dungeon] shell init injection skipped: writer mutex poisoned");
-            }
+            });
         }
     }
 
-    // Spawn a blocking thread for the PTY read loop. The reader holds an
-    // independent cloned handle — the master mutex remains free for
-    // pty_resize to acquire without waiting on a blocked read(). (M-2)
-    let app_clone = app.clone();
-    let sid = session_id.clone();
-    let shutdown_clone = Arc::clone(&shutdown);
-
-    tauri::async_runtime::spawn_blocking(move || {
-        let mut buf = [0u8; 4096];
-        let mut reader = reader;
-
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) => {
-                    // EOF — shell exited.
-                    let _ = app_clone.emit(&format!("pty:exit:{sid}"), ());
-                    break;
-                }
-                Ok(n) => {
-                    if shutdown_clone.load(Ordering::Relaxed) {
-                        break;
-                    }
-                    let encoded = B64.encode(&buf[..n]);
-                    let _ = app_clone.emit(&format!("pty:output:{sid}"), encoded);
-                }
-                Err(_) => {
-                    if !shutdown_clone.load(Ordering::Relaxed) {
-                        let _ = app_clone.emit(&format!("pty:exit:{sid}"), ());
-                    }
-                    break;
-                }
-            }
-        }
-    });
-
-    Ok(())
+    Ok(generation)
 }
 
 /// Write base64-encoded bytes to the PTY's input.
@@ -254,28 +331,30 @@ pub fn pty_write(
     // Clone the Arc out of the map; release the outer lock immediately so
     // concurrent resize calls are never serialised behind this write.
     let session = {
-        let map = state.0.lock().map_err(|_| "state mutex poisoned")?;
+        let map = state.map.lock().map_err(|_| "state mutex poisoned")?;
         map.get(&session_id)
             .ok_or_else(|| format!("session not found: {session_id}"))?
             .clone()
+    };
+
+    // Guard against writes to a Reserved placeholder — the session slot is
+    // claimed but the PTY has not been set up yet.
+    let writer = match &session.state {
+        PtySessionState::Active { writer, .. } => Arc::clone(writer),
+        PtySessionState::Reserved => {
+            return Err(format!("session not ready: {session_id}"));
+        }
     };
 
     let bytes = B64
         .decode(data_b64.as_bytes())
         .map_err(|e| format!("base64 decode failed: {e}"))?;
 
-    let mut writer = session
-        .writer
-        .lock()
-        .map_err(|_| "writer mutex poisoned")?;
+    let mut w = writer.lock().map_err(|_| "writer mutex poisoned")?;
 
-    writer
-        .write_all(&bytes)
-        .map_err(|e| format!("write failed: {e}"))?;
+    w.write_all(&bytes).map_err(|e| format!("write failed: {e}"))?;
 
-    writer
-        .flush()
-        .map_err(|e| format!("flush failed: {e}"))?;
+    w.flush().map_err(|e| format!("flush failed: {e}"))?;
 
     Ok(())
 }
@@ -294,10 +373,18 @@ pub fn pty_resize(
 ) -> Result<(), String> {
     // Clone the Arc out of the map; release the outer lock before acquiring master.
     let session = {
-        let map = state.0.lock().map_err(|_| "state mutex poisoned")?;
+        let map = state.map.lock().map_err(|_| "state mutex poisoned")?;
         map.get(&session_id)
             .ok_or_else(|| format!("session not found: {session_id}"))?
             .clone()
+    };
+
+    // Guard against resize on a Reserved placeholder — no PTY exists yet.
+    let master = match &session.state {
+        PtySessionState::Active { master, .. } => Arc::clone(master),
+        PtySessionState::Reserved => {
+            return Err(format!("session not ready: {session_id}"));
+        }
     };
 
     let size = PtySize {
@@ -307,8 +394,7 @@ pub fn pty_resize(
         pixel_height: 0,
     };
 
-    session
-        .master
+    master
         .lock()
         .map_err(|_| "master mutex poisoned")?
         .resize(size)
@@ -320,11 +406,35 @@ pub fn pty_resize(
 /// Kill the PTY session and clean up.
 ///
 /// Returns `Ok(())` if the session is already absent (idempotent).
+///
+/// `generation` is an optional scoping token. When `Some(g)`, the session is
+/// removed only if its stored generation matches `g` — stale kills (from a
+/// prior mount's cleanup) are no-ops, protecting the active session. When
+/// `None`, the session is removed unconditionally (future-extension safety
+/// valve; all current Terminal.tsx call sites pass `Some(generation)`).
 #[tauri::command]
-pub fn pty_kill(state: State<'_, PtyState>, session_id: String) -> Result<(), String> {
+pub fn pty_kill(
+    state: State<'_, PtyState>,
+    session_id: String,
+    generation: Option<u64>,
+) -> Result<(), String> {
     let session = {
-        let mut map = state.0.lock().map_err(|_| "state mutex poisoned")?;
-        map.remove(&session_id)
+        let mut map = state.map.lock().map_err(|_| "state mutex poisoned")?;
+        match map.get(&session_id) {
+            None => return Ok(()),
+            Some(s) => {
+                let should_remove = match generation {
+                    None => true,
+                    Some(g) => s.generation == g,
+                };
+                if should_remove {
+                    map.remove(&session_id)
+                } else {
+                    // Stale generation — no-op.
+                    return Ok(());
+                }
+            }
+        }
     };
 
     let session = match session {
@@ -336,16 +446,163 @@ pub fn pty_kill(state: State<'_, PtyState>, session_id: String) -> Result<(), St
     // Signal the reader loop to stop after its next read returns.
     session.shutdown.store(true, Ordering::Relaxed);
 
-    // Kill the child process; ignore AlreadyExited.
-    if let Ok(mut child) = session.child.lock() {
-        let _ = child.kill();
-        // On Unix, a process that exits without being waited becomes a zombie
-        // until the parent calls waitpid.
-        // `kill()` terminates the child; `wait()` reaps it. `wait()` returns
-        // immediately if the child already exited.
-        // Reap the child to avoid zombie processes on Unix (POSIX waitpid semantics).
-        let _ = child.wait();
+    // Kill the child process and reap it. Only meaningful for Active sessions;
+    // Reserved placeholders have no child process.
+    if let PtySessionState::Active { child, .. } = &session.state {
+        if let Ok(mut c) = child.lock() {
+            let _ = c.kill();
+            // On Unix, a process that exits without being waited becomes a zombie
+            // until the parent calls waitpid.
+            // `kill()` terminates the child; `wait()` reaps it. `wait()` returns
+            // immediately if the child already exited.
+            // Reap the child to avoid zombie processes on Unix (POSIX waitpid semantics).
+            let _ = c.wait();
+        }
     }
 
     Ok(())
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Build a minimal `PtyState` for tests that only exercise the map/generation
+    /// layer (no real PTY or shell process is spawned).
+    fn make_state() -> PtyState {
+        PtyState::default()
+    }
+
+    /// Insert a `Reserved` `PtySession` with the given `generation` directly into
+    /// the map, bypassing `pty_spawn`. This lets the generation-aware kill tests
+    /// operate without spawning a real shell — a `Reserved` session has no child
+    /// process or writer to clean up.
+    fn insert_fake_session(state: &PtyState, session_id: &str, generation: u64) {
+        let session = Arc::new(PtySession {
+            state: PtySessionState::Reserved,
+            shutdown: Arc::new(AtomicBool::new(false)),
+            generation,
+        });
+
+        state
+            .map
+            .lock()
+            .expect("state mutex poisoned in test")
+            .insert(session_id.to_string(), session);
+    }
+
+    /// Call the generation-aware kill logic directly (mirrors what the updated
+    /// `pty_kill` command does in production).
+    fn kill_with_generation(state: &PtyState, session_id: &str, generation: Option<u64>) {
+        let mut map = state.map.lock().expect("state mutex poisoned in test");
+        if let Some(session) = map.get(session_id) {
+            let should_remove = match generation {
+                None => true,
+                Some(g) => session.generation == g,
+            };
+            if should_remove {
+                let removed = map.remove(session_id).unwrap();
+                removed.shutdown.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// `try_reserve_session_id` must return `Ok(1)` on the first call, then
+    /// `Err("session already exists: …")` on the second call with the same sid,
+    /// leaving the original generation-1 reservation intact.
+    #[test]
+    fn pty_spawn_rejects_duplicate_session_id() {
+        let state = make_state();
+
+        let gen1 =
+            try_reserve_session_id(&state, "sid-A").expect("first reservation must succeed");
+        assert_eq!(gen1, 1, "first allocated generation must be 1");
+
+        let err = try_reserve_session_id(&state, "sid-A")
+            .expect_err("duplicate reservation must return Err");
+        assert!(
+            err.contains("session already exists"),
+            "error message must contain 'session already exists', got: {err}"
+        );
+
+        // Original entry must still be present with generation 1.
+        let map = state.map.lock().unwrap();
+        let entry = map.get("sid-A").expect("original entry must remain in map");
+        assert_eq!(entry.generation, 1, "original entry's generation must be unchanged");
+    }
+
+    /// A `pty_kill` with a stale generation must be a no-op — the session at the
+    /// newer generation must survive.
+    #[test]
+    fn pty_kill_with_stale_generation_is_noop() {
+        let state = make_state();
+
+        // Simulate two successive spawns at the same sid (generation 1 then 2).
+        insert_fake_session(&state, "sid-B", 1);
+        // Overwrite with generation 2 (as if a remount replaced the session).
+        insert_fake_session(&state, "sid-B", 2);
+
+        // A kill carrying the old generation (1) must not remove generation 2.
+        kill_with_generation(&state, "sid-B", Some(1));
+
+        let map = state.map.lock().unwrap();
+        let entry =
+            map.get("sid-B").expect("session at generation 2 must survive a stale kill");
+        assert_eq!(entry.generation, 2, "generation 2 session must be untouched");
+    }
+
+    /// A `pty_kill` with the matching generation must remove the session.
+    #[test]
+    fn pty_kill_with_matching_generation_removes_session() {
+        let state = make_state();
+        insert_fake_session(&state, "sid-C", 5);
+
+        kill_with_generation(&state, "sid-C", Some(5));
+
+        let map = state.map.lock().unwrap();
+        assert!(map.get("sid-C").is_none(), "session must be removed on matching generation");
+    }
+
+    /// A `pty_kill` with `None` generation must remove the session unconditionally.
+    #[test]
+    fn pty_kill_with_none_generation_removes_session() {
+        let state = make_state();
+        insert_fake_session(&state, "sid-D", 7);
+
+        kill_with_generation(&state, "sid-D", None);
+
+        let map = state.map.lock().unwrap();
+        assert!(map.get("sid-D").is_none(), "session must be removed on None generation");
+    }
+
+    /// Tauri argument deserialisation contract: a JSON payload without a
+    /// `generation` field must deserialise to `generation: None` (not an error).
+    ///
+    /// This validates plain serde behaviour (necessary but not sufficient — the
+    /// authoritative gate is the Step 4 manual DevTools smoke test per Ruinor F-B).
+    #[test]
+    fn pty_kill_command_accepts_missing_generation_field() {
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct PtyKillArgs {
+            session_id: String,
+            generation: Option<u64>,
+        }
+
+        let payload = r#"{"session_id": "X"}"#;
+        let result: Result<PtyKillArgs, _> = serde_json::from_str(payload);
+        assert!(
+            result.is_ok(),
+            "deserialisation must succeed for missing generation field; got: {:?}",
+            result.err()
+        );
+        let args = result.unwrap();
+        assert_eq!(args.session_id, "X");
+        assert_eq!(args.generation, None);
+    }
 }

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -40,8 +40,9 @@ vi.mock("@xterm/addon-fit", () => {
   return { FitAddon: vi.fn().mockImplementation(MockFitAddon) };
 });
 
+// Default: pty_spawn resolves to numeric generation 1 (Ruinor F-6).
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
+  invoke: vi.fn().mockResolvedValue(1),
 }));
 
 // Each listen() call resolves to a fresh unlisten spy.
@@ -58,7 +59,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 import { act } from "@testing-library/react";
 import { renderWithProviders } from "../../test-utils/render";
-import { Terminal } from "./Terminal";
+import { Terminal, _clearSpawnChainForTesting } from "./Terminal";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { invoke } from "@tauri-apps/api/core";
@@ -78,6 +79,12 @@ function getFitInstance() {
   return MockFitAddonCls.mock.results[MockFitAddonCls.mock.results.length - 1].value;
 }
 
+// Drain N microtask ticks. Each `await Promise.resolve()` advances the
+// microtask queue by one tick; chaining via .then() avoids a loop construct.
+function drain(n: number): Promise<void> {
+  return n <= 0 ? Promise.resolve() : Promise.resolve().then(() => drain(n - 1));
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("Terminal", () => {
@@ -86,11 +93,17 @@ describe("Terminal", () => {
     // Clear captured unlisten spies from the previous test.
     unlistenSpies.length = 0;
 
-    // Restore invoke to its default behavior (resolves immediately) so that
+    // Clear the module-level spawn-chain Map so prior tests' settled (or
+    // in-flight) kill promises do not block subsequent tests' spawn calls.
+    // Each test gets a clean chain for the session IDs it uses.
+    _clearSpawnChainForTesting();
+
+    // Restore invoke to its default behavior (numeric generation 1) so that
     // tests which set a persistent mockImplementation (e.g. the "does NOT call
     // pty_resize before spawn completes" test) do not leak state into later
     // tests. vi.clearAllMocks() only clears call history, not implementations.
-    (invoke as unknown as AnyMock).mockResolvedValue(undefined);
+    // (Ruinor F-6: pty_spawn must return a numeric generation, not undefined.)
+    (invoke as unknown as AnyMock).mockResolvedValue(1);
 
     // Restore a fresh ResizeObserver spy for each test.
     globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
@@ -177,11 +190,21 @@ describe("Terminal", () => {
 
     unmount();
 
+    // Synchronous cleanup side-effects fire immediately on unmount.
     expect(onDataDisposeSpy).toHaveBeenCalledTimes(1);
     expect(unlisten1).toHaveBeenCalledTimes(1);
     expect(unlisten2).toHaveBeenCalledTimes(1);
-    expect(invoke).toHaveBeenCalledWith("pty_kill", {
-      sessionId: "00000000-0000-0000-0000-000000000001",
+
+    // pty_kill is now deferred (fire-and-forget after the spawn-chain settles).
+    // Use vi.waitFor to handle the async dispatch (Ruinor F-6 timing change).
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "pty_kill",
+        expect.objectContaining({
+          sessionId: "00000000-0000-0000-0000-000000000001",
+          generation: 1,
+        }),
+      );
     });
   });
 
@@ -203,40 +226,51 @@ describe("Terminal", () => {
     expect(mockListen).not.toHaveBeenCalled();
   });
 
-  it("calls pty_kill when unmounted during in-flight spawn", async () => {
+  it("calls pty_kill exactly once via the spawn chain when unmounted during in-flight spawn", async () => {
     const mockInvoke = invoke as unknown as AnyMock;
 
     // Capture the sessionId that will be generated for this render.
     const expectedSessionId = "00000000-0000-0000-0000-000000000001";
 
     // Set up a deferred spawn promise — resolves only when we call resolveSpawn().
-    let resolveSpawn!: () => void;
-    const spawnPromise = new Promise<void>((resolve) => {
+    // Resolves to number (generation token) to match the updated pty_spawn contract.
+    let resolveSpawn!: (value: number) => void;
+    const spawnPromise = new Promise<number>((resolve) => {
       resolveSpawn = resolve;
     });
 
-    // First invoke call is pty_spawn; subsequent calls (pty_kill) resolve immediately.
+    // First invoke call is pty_spawn (deferred); subsequent calls resolve immediately.
     mockInvoke.mockImplementationOnce(() => spawnPromise);
 
     const { unmount } = renderWithProviders(
       <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,
     );
 
-    // Unmount before spawn resolves — cleanup fires pty_kill (no session yet).
+    // Unmount before spawn resolves — cleanup registers the deferred kill in the
+    // spawn chain (no immediate pty_kill IPC fires here; the old early-cancel kill
+    // has been removed per Ruinor F-5).
     act(() => {
       unmount();
     });
 
-    // Now resolve the spawn — the async IIFE resumes and must fire pty_kill again
-    // because `cancelled` is true.
+    // Now resolve the spawn — the spawn-chain's cleanup .then fires pty_kill exactly once.
     await act(async () => {
-      resolveSpawn();
+      resolveSpawn(1);
       await spawnPromise;
     });
 
+    // Drain microtasks so the deferred kill chain settles.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Exactly one pty_kill IPC call — the deferred kill from cleanup's spawn chain.
+    // The old IIFE early-cancel kill is removed (Ruinor F-5), so only one fires.
+    const killCalls = mockInvoke.mock.calls.filter((c: unknown[]) => c[0] === "pty_kill");
+    expect(killCalls).toHaveLength(1);
     expect(mockInvoke).toHaveBeenCalledWith(
       "pty_kill",
-      expect.objectContaining({ sessionId: expectedSessionId }),
+      expect.objectContaining({ sessionId: expectedSessionId, generation: 1 }),
     );
   });
 
@@ -341,8 +375,9 @@ describe("Terminal", () => {
     const mockInvoke = invoke as unknown as AnyMock;
 
     // Deferred spawn: resolves only when we call resolveSpawn().
-    let resolveSpawn!: () => void;
-    const spawnPromise = new Promise<void>((resolve) => {
+    // Resolves to number (generation token) to match the updated pty_spawn contract.
+    let resolveSpawn!: (value: number) => void;
+    const spawnPromise = new Promise<number>((resolve) => {
       resolveSpawn = resolve;
     });
 
@@ -374,7 +409,7 @@ describe("Terminal", () => {
 
     // Resolve spawn and wait for the flush loop to drain.
     await act(async () => {
-      resolveSpawn();
+      resolveSpawn(1);
       await spawnPromise;
     });
 
@@ -392,8 +427,8 @@ describe("Terminal", () => {
     const mockInvoke = invoke as unknown as AnyMock;
 
     // Deferred spawn.
-    let resolveSpawn!: () => void;
-    const spawnPromise = new Promise<void>((resolve) => {
+    let resolveSpawn!: (value: number) => void;
+    const spawnPromise = new Promise<number>((resolve) => {
       resolveSpawn = resolve;
     });
 
@@ -423,7 +458,7 @@ describe("Terminal", () => {
     // Now resolve spawn — the IIFE resumes but cancelled is true; flush loop
     // checks cancelled and breaks immediately without calling pty_write.
     await act(async () => {
-      resolveSpawn();
+      resolveSpawn(1);
       await spawnPromise;
     });
 
@@ -556,12 +591,157 @@ describe("Terminal", () => {
     expect(oscHandlerDisposeSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("does not surface spurious errors on cross-mount remount with the same sessionId (StrictMode race)", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+
+    // ── Session-aware mock (Ruinor F-9 option (a)) ────────────────────────────
+    // Track which sessions are live so pty_write correctly rejects against a
+    // killed session — this is what makes the test fail on main for the right
+    // reason (Mount A's deferred kill removes "X", causing Mount B's first
+    // pty_write to reject with "session not found").
+    const liveSessions = new Set<string>();
+    const sessionGenerations = new Map<string, number>();
+    let nextGeneration = 0;
+
+    // ── Deferred spawn promises ────────────────────────────────────────────────
+    // spawnA gates Mount A's pty_spawn; spawnB gates Mount B's pty_spawn.
+    // We resolve them manually to control ordering.
+    let resolveSpawnA!: () => void;
+    let resolveSpawnB!: () => void;
+    const deferredA = new Promise<void>((resolve) => {
+      resolveSpawnA = resolve;
+    });
+    const deferredB = new Promise<void>((resolve) => {
+      resolveSpawnB = resolve;
+    });
+
+    // Track which deferred to consume next for pty_spawn calls.
+    let spawnCallCount = 0;
+
+    mockInvoke.mockImplementation(async (cmd: string, args: Record<string, unknown>) => {
+      if (cmd === "pty_spawn") {
+        const sid = args["sessionId"] as string;
+        const callIndex = spawnCallCount++;
+        // Gate on the appropriate deferred promise.
+        if (callIndex === 0) {
+          await deferredA;
+        } else {
+          await deferredB;
+        }
+        // Session-aware duplicate check.
+        if (liveSessions.has(sid)) {
+          throw new Error(`session already exists: ${sid}`);
+        }
+        nextGeneration += 1;
+        liveSessions.add(sid);
+        sessionGenerations.set(sid, nextGeneration);
+        return nextGeneration;
+      }
+      if (cmd === "pty_kill") {
+        const sid = args["sessionId"] as string;
+        const gen = args["generation"] as number | undefined;
+        if (gen === undefined || sessionGenerations.get(sid) === gen) {
+          liveSessions.delete(sid);
+          sessionGenerations.delete(sid);
+        }
+        // stale generation → no-op
+        return undefined;
+      }
+      if (cmd === "pty_write") {
+        const sid = args["sessionId"] as string;
+        if (!liveSessions.has(sid)) {
+          throw new Error(`pty write failed: session not found: ${sid}`);
+        }
+        return undefined;
+      }
+      return undefined;
+    });
+
+    // ── Mount A, immediately unmount, mount B (mirrors StrictMode cycle) ───────
+    let unmountA!: () => void;
+    let unmountB!: () => void;
+    await act(() => {
+      const resultA = renderWithProviders(<Terminal sessionId="X" />);
+      unmountA = resultA.unmount;
+    });
+    await act(() => {
+      unmountA();
+      const resultB = renderWithProviders(<Terminal sessionId="X" />);
+      unmountB = resultB.unmount;
+    });
+
+    // ── Resolve spawnA (generation 1 allocated, "X" added to liveSessions) ─────
+    await act(async () => {
+      resolveSpawnA();
+      await deferredA;
+      // Drain extra microtask rounds so Mount A's IIFE (cancelled→return),
+      // the cleanup kill, and killPromise settling all complete within this act.
+      await drain(10);
+    });
+
+    // ── Resolve spawnB (should be serialised after Mount A's kill is issued) ───
+    // deferredB may already be resolvable (killPromise settled above). Resolve it
+    // and drain until Mount B's IIFE registers its listen calls.
+    await act(async () => {
+      resolveSpawnB();
+      await deferredB;
+      // Drain so the mock returns, spawnPromise resolves, and the IIFE reaches listen.
+      await drain(10);
+    });
+
+    const allCalls = mockInvoke.mock.calls as [string, Record<string, unknown>][];
+    const spawnCalls = allCalls.filter((c) => c[0] === "pty_spawn");
+    const killCalls = allCalls.filter((c) => c[0] === "pty_kill");
+
+    // ── Assertion 1: ordering — Mount A's kill was issued before Mount B's spawn
+    const spawnAIndex = allCalls.findIndex((c) => c[0] === "pty_spawn");
+    const killAIndex = allCalls.findIndex(
+      (c) => c[0] === "pty_kill" && (c[1]["generation"] as number) === 1,
+    );
+    const spawnBIndex = allCalls.findIndex((c, i) => c[0] === "pty_spawn" && i > spawnAIndex);
+    expect(spawnCalls.length).toBeGreaterThanOrEqual(2);
+    expect(killCalls.length).toBeGreaterThanOrEqual(1);
+    expect(killAIndex).toBeGreaterThan(-1); // kill for gen 1 was issued
+    expect(spawnBIndex).toBeGreaterThan(killAIndex); // Mount B spawns after Mount A's kill
+
+    // ── Assertion 2: Mount B's listen calls were registered ───────────────────
+    // Mount B's IIFE calls listen after spawnB resolves. Drain a few more rounds
+    // to ensure the IIFE's listen registrations complete.
+    await act(async () => {
+      await drain(20);
+    });
+    const mockListen = listen as unknown as AnyMock;
+    const listenNames = (mockListen.mock.calls as [string][]).map((c) => c[0]);
+    // Mount B registers pty:output:X and pty:exit:X (Mount A returned early due
+    // to cancelled=true, so its listen calls never fired).
+    expect(listenNames.filter((n) => n === "pty:output:X").length).toBeGreaterThanOrEqual(1);
+    expect(listenNames.filter((n) => n === "pty:exit:X").length).toBeGreaterThanOrEqual(1);
+
+    // ── Assertion 3: no spurious error rendered in any terminal canvas ─────────
+    // Iterate ALL xterm instances created across both mounts (not just the last).
+    const MockXTerm = XTerm as unknown as AnyMock;
+    const allWritelnCalls: unknown[][] = [];
+    for (const result of MockXTerm.mock.results as Array<{ value: { writeln: AnyMock } }>) {
+      if (result.value?.writeln?.mock?.calls) {
+        allWritelnCalls.push(...(result.value.writeln.mock.calls as unknown[][]));
+      }
+    }
+    for (const [arg] of allWritelnCalls) {
+      expect(String(arg)).not.toContain("[failed to start shell");
+      expect(String(arg)).not.toContain("[pty write failed");
+    }
+
+    // Cleanup.
+    unmountB();
+  });
+
   it("does not call term.writeln on pty_write error after unmount (flush-path .catch cancelled guard)", async () => {
     const mockInvoke = invoke as unknown as AnyMock;
 
     // Deferred spawn so we can queue a keystroke before spawn resolves.
-    let resolveSpawn!: () => void;
-    const spawnPromise = new Promise<void>((resolve) => {
+    // Resolves to number (generation token) to match the updated pty_spawn contract.
+    let resolveSpawn!: (value: number) => void;
+    const spawnPromise = new Promise<number>((resolve) => {
       resolveSpawn = resolve;
     });
 
@@ -593,12 +773,12 @@ describe("Terminal", () => {
 
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === "pty_write") return ptyWritePromise;
-      return Promise.resolve(undefined);
+      return Promise.resolve(1);
     });
 
     // Resolve spawn — flush loop runs, calls pty_write (promise is still pending).
     await act(async () => {
-      resolveSpawn();
+      resolveSpawn(1);
       await spawnPromise;
     });
 

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -19,6 +19,39 @@ interface TerminalProps {
   onContextChange?: (ctx: SessionContext) => void;
 }
 
+// ── Per-sid spawn-chain (Ruinor F-1 resolution) ───────────────────────────────
+//
+// Module-level per-sid serialisation queue. Every pty_spawn for a given
+// sessionId is awaited after the previous mount's full spawn-then-kill chain
+// has settled. This prevents StrictMode mount → unmount → remount from
+// colliding two pty_spawn calls at the backend, and prevents Mount A's
+// deferred kill from racing Mount B's fresh spawn.
+//
+// Memory bound (Ruinor F-11): each entry is a (string, settled-Promise) pair,
+// ~100 bytes per entry. 10,000 distinct sessionIds across an app session
+// therefore costs ~1 MB. We do NOT delete entries when a kill settles because
+// a sessionId can be re-mounted later (e.g., Tabs unmount/remount, future
+// session-restore features) and an early delete would race a re-mount that
+// arrives during the kill window. The trade-off is acceptable: 1 MB at
+// 10,000 entries is negligible vs. the correctness cost of a wrong-time
+// delete. If a future feature creates >10,000 unique sessionIds in one
+// app session, revisit with an LRU eviction strategy.
+//
+// Type-safety note (Ruinor F-12): the Map value is typed Promise<unknown>
+// because mount-cleanup chains mix Promise<number> (spawn) and Promise<void>
+// (kill). When a caller needs the generation token, USE THE LOCAL
+// `spawnPromise` REFERENCE (typed Promise<number>), NOT spawnChain.get(sid)
+// (typed Promise<unknown> | undefined). Reading the generation off the Map
+// would silently lose type information and require an unsafe cast.
+const spawnChain = new Map<string, Promise<unknown>>();
+
+// ── Test utility ──────────────────────────────────────────────────────────────
+// Exported so Vitest beforeEach hooks can clear the chain between tests.
+// Do NOT call this in production code.
+export function _clearSpawnChainForTesting(): void {
+  spawnChain.clear();
+}
+
 export function Terminal({ sessionId, onContextChange }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Stable ref so OSC handlers always call the latest callback without needing
@@ -159,16 +192,38 @@ export function Terminal({ sessionId, onContextChange }: TerminalProps) {
     });
     observer.observe(containerRef.current);
 
-    // ── Async IIFE: spawn shell + subscribe to events ─────────────────────────
+    // ── Spawn-chain: append this mount's spawn to the per-sid chain ───────────
+    // `previousChain` is whatever the prior mount (or a prior kill) settled as.
+    // The `.catch(() => undefined)` ensures a prior failure does not poison this
+    // mount — every mount gets a clean start regardless of what came before.
+    //
+    // `spawnPromise` is typed Promise<number> (the generation token returned by
+    // the backend). Always reference this local variable when you need the
+    // generation — do NOT read it back from spawnChain.get(sessionId), which is
+    // typed Promise<unknown> and would require an unsafe cast (Ruinor F-12).
+    const dims = fitAddon.proposeDimensions() ?? { cols: 80, rows: 24 };
+    const previousChain = spawnChain.get(sessionId) ?? Promise.resolve();
+    const spawnPromise: Promise<number> = previousChain
+      .catch(() => undefined)
+      .then(() => invoke<number>("pty_spawn", { sessionId, cols: dims.cols, rows: dims.rows }));
+
+    // Store a kill-tolerant version of spawnPromise in the chain so the next
+    // mount can extend it safely. The local `spawnPromise` reference (typed
+    // Promise<number>) is retained below for the IIFE and cleanup to use.
+    spawnChain.set(
+      sessionId,
+      spawnPromise.catch(() => undefined),
+    );
+
+    // ── Async IIFE: subscribe to events after spawn resolves ──────────────────
     void (async () => {
-      const dims = fitAddon.proposeDimensions() ?? { cols: 80, rows: 24 };
+      let generation: number | undefined;
 
       try {
-        await invoke("pty_spawn", {
-          sessionId,
-          cols: dims.cols,
-          rows: dims.rows,
-        });
+        // Await the spawn-chain promise (which invokes pty_spawn on the backend).
+        // This ensures Mount B's pty_spawn always starts after Mount A's pty_kill
+        // has been issued (the spawn-chain serialises them per-sid).
+        generation = await spawnPromise;
       } catch (err) {
         if (!cancelled) {
           term.writeln(`\r\n[failed to start shell: ${String(err)}]`);
@@ -176,14 +231,12 @@ export function Terminal({ sessionId, onContextChange }: TerminalProps) {
         return;
       }
 
-      // If the component unmounted while pty_spawn was in flight, the cleanup
-      // function already fired pty_kill (which found no session yet and returned
-      // Ok). Now that the session exists on the backend, kill it explicitly so
-      // the shell + reader thread are not orphaned.
-      if (cancelled) {
-        void invoke("pty_kill", { sessionId });
-        return;
-      }
+      // If the component unmounted while pty_spawn was in flight, cleanup's
+      // deferred kill (via the spawn chain) handles termination — no need to
+      // invoke pty_kill here.
+      // Cleanup's deferred kill (via the spawn chain) handles termination if
+      // cancelled — no need to invoke pty_kill here.
+      if (cancelled) return;
 
       // ── Listen for PTY output ───────────────────────────────────────────────
       // The payload is a base64-encoded string. We decode it to a Uint8Array
@@ -203,12 +256,15 @@ export function Terminal({ sessionId, onContextChange }: TerminalProps) {
         term.write(bytes);
       });
 
+      // The exit listener captures `generation` to scope its pty_kill to this
+      // mount's session — it cannot accidentally kill a successor session at the
+      // same sessionId (Ruinor F-4).
       unlistenExit = await listen(`pty:exit:${sessionId}`, () => {
         term.writeln("\r\n[process exited]");
         // Remove the dead session from the backend HashMap. pty_kill is
         // idempotent (returns Ok when the session is absent), so this is safe
         // even if cleanup has already run.
-        void invoke("pty_kill", { sessionId });
+        void invoke("pty_kill", { sessionId, generation });
       });
 
       if (cancelled) return;
@@ -253,8 +309,16 @@ export function Terminal({ sessionId, onContextChange }: TerminalProps) {
       osc7337Handler.dispose();
       unlistenOutput?.();
       unlistenExit?.();
-      // Fire-and-forget: kill errors are non-fatal during teardown.
-      void invoke("pty_kill", { sessionId });
+      // Defer pty_kill until the in-flight spawnPromise has settled.
+      // Use the local spawnPromise (typed Promise<number>) so the generation is
+      // typed as number in the .then callback. Reading from spawnChain here
+      // would erase the type to unknown (Ruinor F-12).
+      // The cleanup remains synchronous from React's perspective — the .then(...)
+      // chain is fire-and-forget and React does not await it.
+      const killPromise = spawnPromise
+        .then((generation) => invoke("pty_kill", { sessionId, generation }))
+        .catch(() => undefined); // spawn failed → nothing to kill
+      spawnChain.set(sessionId, killPromise);
       term.dispose();
     };
   }, [sessionId]);

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -1,42 +1,115 @@
-vi.mock("@xterm/xterm", () => ({
-  Terminal: vi.fn().mockImplementation(() => ({
-    write: vi.fn(),
-    writeln: vi.fn(),
-    open: vi.fn(),
-    loadAddon: vi.fn(),
-    dispose: vi.fn(),
-    onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
-    parser: { registerOscHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }) },
-  })),
-}));
+vi.mock("@xterm/xterm", () => {
+  // Each instance gets its own fresh spies so tests can introspect per-instance
+  // writeln calls across multiple mounts. The `_vi` reference satisfies the
+  // consistent-function-scoping rule by capturing a value from the outer closure.
+  const _vi = vi;
+  function MockTerminal() {
+    return {
+      write: _vi.fn(),
+      writeln: _vi.fn(),
+      open: _vi.fn(),
+      loadAddon: _vi.fn(),
+      dispose: _vi.fn(),
+      onData: _vi.fn().mockReturnValue({ dispose: _vi.fn() }),
+      parser: { registerOscHandler: _vi.fn().mockReturnValue({ dispose: _vi.fn() }) },
+    };
+  }
+  return { Terminal: vi.fn().mockImplementation(MockTerminal) };
+});
 
-vi.mock("@xterm/addon-fit", () => ({
-  FitAddon: vi.fn().mockImplementation(() => ({
-    fit: vi.fn(),
-    proposeDimensions: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
-  })),
-}));
+vi.mock("@xterm/addon-fit", () => {
+  const _vi = vi;
+  function MockFitAddon() {
+    return {
+      fit: _vi.fn(),
+      proposeDimensions: _vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+    };
+  }
+  return { FitAddon: vi.fn().mockImplementation(MockFitAddon) };
+});
 
+// Default: pty_spawn resolves to numeric generation 1 (consistent with Step 5).
+// The existing flex-contract test renders AppLayout with no cards so invoke is
+// never called — this change is a no-op for that test.
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
+  invoke: vi.fn().mockResolvedValue(1),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn().mockImplementation(() => Promise.resolve(vi.fn())),
 }));
 
+import React from "react";
+import { act } from "@testing-library/react";
 import { renderWithProviders } from "../../test-utils/render";
 import { AppLayout } from "./AppLayout";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { Terminal as XTerm } from "@xterm/xterm";
+import { _clearSpawnChainForTesting } from "../Terminal/Terminal";
+
+type AnyMock = ReturnType<typeof vi.fn>;
+
+// ── Session-aware mock builder ────────────────────────────────────────────────
+// Mirrors the Step 1 pattern from Terminal.test.tsx. Install per-test via
+// mockInvoke.mockImplementation(...); tear down is handled by beforeEach reset.
+function installSessionAwareMock(mockInvoke: AnyMock) {
+  const liveSessions = new Set<string>();
+  const sessionGenerations = new Map<string, number>();
+  let nextGeneration = 0;
+
+  mockInvoke.mockImplementation(async (cmd: string, args: Record<string, unknown>) => {
+    if (cmd === "pty_spawn") {
+      const sid = args["sessionId"] as string;
+      if (liveSessions.has(sid)) {
+        throw new Error(`session already exists: ${sid}`);
+      }
+      nextGeneration += 1;
+      liveSessions.add(sid);
+      sessionGenerations.set(sid, nextGeneration);
+      return nextGeneration;
+    }
+    if (cmd === "pty_kill") {
+      const sid = args["sessionId"] as string;
+      const gen = args["generation"] as number | undefined;
+      if (gen === undefined || sessionGenerations.get(sid) === gen) {
+        liveSessions.delete(sid);
+        sessionGenerations.delete(sid);
+      }
+      return undefined;
+    }
+    if (cmd === "pty_write") {
+      const sid = args["sessionId"] as string;
+      if (!liveSessions.has(sid)) {
+        throw new Error(`pty write failed: session not found: ${sid}`);
+      }
+      return undefined;
+    }
+    return undefined;
+  });
+}
 
 describe("AppLayout", () => {
   beforeEach(() => {
-    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
-      observe: vi.fn(),
-      unobserve: vi.fn(),
-      disconnect: vi.fn(),
-    })) as unknown as typeof ResizeObserver;
+    vi.clearAllMocks();
+    // Clear the module-level spawn-chain Map so prior tests' promises do not
+    // block subsequent tests' spawn calls.
+    _clearSpawnChainForTesting();
+    // Restore default invoke behaviour (numeric generation 1) after tests that
+    // install a session-aware implementation.
+    (invoke as unknown as AnyMock).mockResolvedValue(1);
+
+    globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
+      return {
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+        disconnect: vi.fn(),
+      };
+    }) as unknown as typeof ResizeObserver;
   });
 
+  // ── Pre-existing flex-contract regression test (PR #22) ───────────────────
+  // Must be preserved verbatim — it is a load-bearing regression guard.
   it("applies flex:1 and minWidth:0 to the AppShell root element", () => {
     const { container } = renderWithProviders(
       <AppLayout
@@ -57,5 +130,115 @@ describe("AppLayout", () => {
     expect((appShellRoot as HTMLElement).style.flex).not.toBe("");
     expect((appShellRoot as HTMLElement).style.flexGrow).toBe("1");
     expect((appShellRoot as HTMLElement).style.minWidth).toBe("0px");
+  });
+
+  // ── Multi-card integration test (Step 3) ──────────────────────────────────
+
+  it("renders multiple cards under StrictMode without surfacing pty errors in any terminal", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    installSessionAwareMock(mockInvoke);
+
+    await act(async () => {
+      renderWithProviders(
+        <React.StrictMode>
+          <AppLayout
+            cards={[{ id: "A" }, { id: "B" }, { id: "C" }]}
+            onAddCard={vi.fn()}
+            onRemoveCard={vi.fn()}
+            activeId="A"
+            onActiveIdChange={vi.fn()}
+          />
+        </React.StrictMode>,
+      );
+    });
+
+    // Wait for all listen() calls to settle — at least two per terminal
+    // (pty:output + pty:exit), times 3 terminals.
+    const mockListen = listen as unknown as AnyMock;
+    await vi.waitFor(() => {
+      expect((mockListen.mock.calls as unknown[]).length).toBeGreaterThanOrEqual(6);
+    });
+
+    // Drain microtasks so any in-flight spawns and error callbacks settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Iterate every xterm instance created across the render.
+    const MockXTerm = XTerm as unknown as AnyMock;
+    const allWritelnCalls: unknown[][] = [];
+    for (const result of MockXTerm.mock.results as Array<{ value: { writeln: AnyMock } }>) {
+      if (result.value?.writeln?.mock?.calls) {
+        allWritelnCalls.push(...(result.value.writeln.mock.calls as unknown[][]));
+      }
+    }
+    for (const [arg] of allWritelnCalls) {
+      expect(String(arg)).not.toContain("[failed to start shell");
+      expect(String(arg)).not.toContain("[pty write failed");
+    }
+  });
+
+  it("rapid card-add does not produce duplicate-spawn errors at the backend boundary", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    installSessionAwareMock(mockInvoke);
+
+    // Render with one card first.
+    const { rerender } = renderWithProviders(
+      <AppLayout
+        cards={[{ id: "card-1" }]}
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        activeId="card-1"
+        onActiveIdChange={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Add three more cards in quick succession (mimicking + button spam).
+    await act(async () => {
+      rerender(
+        <AppLayout
+          cards={[{ id: "card-1" }, { id: "card-2" }, { id: "card-3" }, { id: "card-4" }]}
+          onAddCard={vi.fn()}
+          onRemoveCard={vi.fn()}
+          activeId="card-1"
+          onActiveIdChange={vi.fn()}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // No pty_spawn invocation should have rejected with "session already exists".
+    // Each card has a unique id so no duplicate spawns should occur.
+    const spawnCalls = (mockInvoke.mock.calls as [string, unknown][]).filter(
+      (c) => c[0] === "pty_spawn",
+    );
+    // There should be at least one spawn per unique card.
+    expect(spawnCalls.length).toBeGreaterThanOrEqual(4);
+
+    // Check no invoke returned a rejection for "session already exists".
+    // The session-aware mock throws; if the spawn-chain is correct those throws
+    // won't occur because each card has a distinct id.
+    const allResults = mockInvoke.mock.results as Array<{
+      type: string;
+      value: unknown;
+    }>;
+    const settledResults = await Promise.all(
+      allResults
+        .filter((r) => r.type === "return" && r.value instanceof Promise)
+        .map((r) => (r.value as Promise<unknown>).catch((e: unknown) => e)),
+    );
+    for (const val of settledResults) {
+      if (val instanceof Error) {
+        expect(val.message).not.toContain("session already exists");
+      }
+    }
   });
 });

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -147,6 +147,8 @@ describe("AppLayout", () => {
             onRemoveCard={vi.fn()}
             activeId="A"
             onActiveIdChange={vi.fn()}
+            contexts={{}}
+            onContextChange={vi.fn()}
           />
         </React.StrictMode>,
       );
@@ -190,6 +192,8 @@ describe("AppLayout", () => {
         onRemoveCard={vi.fn()}
         activeId="card-1"
         onActiveIdChange={vi.fn()}
+        contexts={{}}
+        onContextChange={vi.fn()}
       />,
     );
 
@@ -206,6 +210,8 @@ describe("AppLayout", () => {
           onRemoveCard={vi.fn()}
           activeId="card-1"
           onActiveIdChange={vi.fn()}
+          contexts={{}}
+          onContextChange={vi.fn()}
         />,
       );
       await Promise.resolve();


### PR DESCRIPTION
Cards 2+ displayed `[pty write failed: session not found]` immediately on mount because React StrictMode's double-mount caused an async `pty_kill` from the first mount's cleanup to remove the fresh session registered by the second mount's `pty_spawn`. The fix serialises all `pty_spawn`/`pty_kill` IPC calls per `sessionId` via a module-level spawn-chain on the frontend, ensuring Mount B's spawn always starts after Mount A's full spawn-then-kill chain completes. The Rust backend gains a generation token on each session so stale kills are unconditional no-ops rather than accidentally removing a successor's session.