### PR TITLE
fix(terminal): restore SHELL_INIT_POLYGLOT injection in pty_spawn

### DIFF
--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -257,8 +257,27 @@ pub async fn pty_spawn(
             }
             return Err(e);
         }
-        Ok((master, writer, child, reader)) => {
+        Ok((master, mut writer, child, reader)) => {
             let shutdown = Arc::new(AtomicBool::new(false));
+
+            // Inject the shell init polyglot on Unix so bash/zsh emit OSC 7 (CWD) and
+            // OSC 7337 (git context) after every prompt cycle. We write to the bare
+            // `writer` binding here — before it is wrapped in `Arc<Mutex<>>` and inserted
+            // into the map — so the write is uncontended and cannot race with `pty_write`,
+            // `pty_kill`, or a remount-spawn on the same sid (the session is still
+            // unreachable from any other code path at this point).
+            //
+            // Soft failure: on write or flush error we log and proceed. A terminal without
+            // OSC context is preferable to a failed `pty_spawn`. This matches the
+            // behaviour shipped in commit 5b64097 prior to the lifecycle refactor.
+            #[cfg(unix)]
+            {
+                if let Err(e) = writer.write_all(SHELL_INIT_POLYGLOT.as_bytes()) {
+                    eprintln!("[ai-dungeon] shell init injection write failed: {e}");
+                } else if let Err(e) = writer.flush() {
+                    eprintln!("[ai-dungeon] shell init injection flush failed: {e}");
+                }
+            }
 
             // Replace the Reserved placeholder with the fully-constructed Active session.
             let session = Arc::new(PtySession {


### PR DESCRIPTION
## Problem

Commit 2383818 removed the `write_all` call that injected the `SHELL_INIT_POLYGLOT` script into the PTY master during `pty_spawn`, but left the constant declaration in place. The injection is the mechanism that registers the OSC 7 (CWD) and OSC 7337 (git context) hooks on shell startup. Without it, those hooks never fire, so the SessionCard receives no working-directory or git-context updates.

## Fix

Re-wire the injection immediately after the PTY writer is obtained, before it is wrapped in `Arc<Mutex<>>`. This placement is safe by construction: the write is uncontended at spawn time and cannot race with `pty_write` or a remount-spawn, because the `Arc<Mutex<>>` does not yet exist.

Write and flush errors are split into distinct `eprintln!` messages for diagnostic clarity. Soft-failure semantics are preserved: an injection error is logged but `pty_spawn` still returns `Ok(generation)`, so a failure to inject degrades gracefully rather than aborting the session.