### PR TITLE
feat(ui): add keyboard shortcuts for tab navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ AI coding assistants increasingly run as CLIs that hold long-lived, stateful ses
 ## Key Features
 
 - **Card-as-tab terminals** — each card in the sidebar is a vertical tab; clicking it switches which terminal is visible in the main pane. PTY sessions are preserved across switches — the shell keeps running and scrollback is intact even when a tab is not visible.
+- **Keyboard tab navigation** — global shortcuts work whether focus is in the terminal or the sidebar. `Cmd+ArrowLeft` / `Cmd+ArrowRight` (macOS) or `Ctrl+ArrowLeft` / `Ctrl+ArrowRight` (Windows/Linux) cycle tabs with wrap-around. `Cmd/Ctrl+1` through `Cmd/Ctrl+9` jump directly to a tab by position. All eleven shortcuts suppress the WebView's default back/forward navigation unconditionally.
 - **Multiple AI CLIs in one place** — designed to host tools like Claude Code, OpenCode, and other terminal-based AI assistants.
 - **Native desktop app** — built on Tauri v2 for a fast, lightweight shell around a modern web UI.
 - **Live session metadata** — terminals receive structured session info (slug, repo, branch, working directory, PR/issue numbers) via OSC 6800 escape sequences emitted by the CLI. Each tab's sidebar card updates automatically; tabs that have not yet emitted a payload display placeholder data. All incoming data is validated before it enters app state. See [docs/project-structure.md](docs/project-structure.md#osc-session-context-flow-6800--7--7337).

--- a/TESTING.md
+++ b/TESTING.md
@@ -92,6 +92,14 @@ After `pnpm tauri dev` opens the app window, perform the following checks to con
 15. **No spurious errors on cards 2+** — Click `+` three times to create cards 2, 3, and 4. Inspect every terminal pane. No pane must display `[pty write failed: session not found: …]` or `[failed to start shell: session already exists]` on initial render. Type a command (e.g. `echo ok`) in each terminal and confirm it produces output.
 16. **No orphaned shells after rapid add/remove** — Rapidly add five cards, then remove all of them, then add five again. Run the ppid-filtered orphan check from step 7. The shell count must equal the number of currently-live cards exactly. Any excess indicates orphaned processes — treat as a regression and do not merge.
 
+### Keyboard tab navigation checks
+
+17. **Cycle with terminal focus** — Add three cards. Click into the third card's terminal (xterm textarea has focus). Press `Cmd+ArrowRight` (macOS) or `Ctrl+ArrowRight` (Windows/Linux). Confirm the active tab wraps to card 1. Press `Cmd+ArrowLeft` / `Ctrl+ArrowLeft`. Confirm the active tab returns to card 3.
+18. **Cycle with sidebar focus** — Click a sidebar card label so focus is in the navbar. Press `Cmd+ArrowRight` / `Ctrl+ArrowRight`. Confirm the active tab changes. The shortcut must work regardless of where focus is in the app.
+19. **Direct jump** — Add at least three cards. Press `Cmd+2` / `Ctrl+2`. Confirm the second card becomes active. Press `Cmd+3` / `Ctrl+3`. Confirm the third card becomes active.
+20. **Direct jump out of range** — With two cards active, press `Cmd+9` / `Ctrl+9`. Confirm the active tab does not change and no error occurs.
+21. **No WebView back-navigation** — Press `Cmd+ArrowLeft` / `Ctrl+ArrowLeft` with only one card open (cycling is a no-op). Confirm the WebView does not navigate back (no blank or prior-page flash).
+
 ## CI
 
 `pnpm lint`, `pnpm format:check`, and `pnpm test` run automatically on every pull request and push to `main` via the `check` job in `.github/workflows/test.yml`.

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -15,6 +15,8 @@ let osc7337DisposeSpy: ReturnType<typeof vi.fn>;
 
 const registerOscHandlerSpy = vi.fn();
 
+const attachKeyHandlerSpy = vi.fn();
+
 vi.mock("@xterm/xterm", () => {
   const writeSpy = vi.fn();
   const writelnSpy = vi.fn();
@@ -30,6 +32,7 @@ vi.mock("@xterm/xterm", () => {
       dispose: disposeSpy,
       onData: onDataSpy,
       parser: { registerOscHandler: registerOscHandlerSpy },
+      attachCustomKeyEventHandler: attachKeyHandlerSpy,
     };
   }
   return { Terminal: vi.fn().mockImplementation(MockTerminal) };
@@ -1371,5 +1374,83 @@ describe("Terminal", () => {
     expect(cbB).toHaveBeenCalledWith({ workingDirectory: "/Users/me/second" });
     // cbA must NOT have been called again.
     expect(cbA).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Custom key event handler ───────────────────────────────────────────────────
+
+describe("custom key event handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unlistenSpies.length = 0;
+    _clearSpawnChainForTesting();
+    (invoke as unknown as AnyMock).mockResolvedValue(1);
+    globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+    }) as unknown as typeof ResizeObserver;
+  });
+
+  function getHandler() {
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
+    return attachKeyHandlerSpy.mock.calls[0][0] as (e: KeyboardEvent) => boolean;
+  }
+
+  it("returns false for mod+ArrowLeft (metaKey)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "ArrowLeft", metaKey: true }))).toBe(false);
+  });
+
+  it("returns false for mod+ArrowRight (metaKey)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "ArrowRight", metaKey: true }))).toBe(false);
+  });
+
+  it("returns false for mod+ArrowLeft (ctrlKey — Linux/Windows path)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "ArrowLeft", ctrlKey: true }))).toBe(false);
+  });
+
+  it("returns false for mod+1 (metaKey)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "1", metaKey: true }))).toBe(false);
+  });
+
+  it("returns false for mod+9 (metaKey)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "9", metaKey: true }))).toBe(false);
+  });
+
+  it("returns true for mod+0 (not in scope)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "0", metaKey: true }))).toBe(true);
+  });
+
+  it("returns true for unmodified ArrowLeft", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "ArrowLeft" }))).toBe(true);
+  });
+
+  it("returns true for alphabetic key with modifier", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "a", metaKey: true }))).toBe(true);
+  });
+
+  it("returns true for keyup event (only keydown is intercepted)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keyup", { key: "ArrowLeft", metaKey: true }))).toBe(true);
+  });
+
+  it("returns true for mod+Shift+1 (shift-prefixed combo passes through — tmux/screen regression guard)", () => {
+    const handler = getHandler();
+    expect(handler(new KeyboardEvent("keydown", { key: "1", metaKey: true, shiftKey: true }))).toBe(
+      true,
+    );
+  });
+
+  it("returns true for mod+Alt+ArrowLeft (alt-prefixed combo passes through — F-1 regression guard)", () => {
+    const handler = getHandler();
+    expect(
+      handler(new KeyboardEvent("keydown", { key: "ArrowLeft", metaKey: true, altKey: true })),
+    ).toBe(true);
   });
 });

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -106,6 +106,49 @@ export function Terminal({
     const term = new XTerm();
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
+
+    // Allow the global tab-switching hotkeys to escape xterm.
+    // Returning false tells xterm "do not handle this event"; the event
+    // continues to propagate so the document-level useHotkeys listener
+    // registered in AppLayout (attached at document.documentElement) can
+    // act on it.
+    // The set covers the eleven combos in scope: mod+ArrowLeft,
+    // mod+ArrowRight, and mod+1..mod+9. mod+0 is intentionally NOT in
+    // this set (matches AppLayout's hotkey registrations).
+    //
+    // The `shiftKey || altKey` early-return is load-bearing: Mantine's
+    // parseHotkey for "mod+1" demands { shift: false, alt: false }, so
+    // useHotkeys does NOT fire for combos like mod+Shift+1 or
+    // mod+Alt+ArrowLeft. If we returned false for those here, the combo
+    // would be silently swallowed (xterm ignores it AND useHotkeys
+    // ignores it). Real-world impact: tmux/screen users routinely use
+    // Ctrl+Shift+1..9 for window selection inside the terminal — those
+    // must reach the shell. So we restrict interception to bare mod+key
+    // (no shift, no alt), which is exactly the eleven combos useHotkeys
+    // is registered for.
+    //
+    // DIGIT_KEYS is an explicit Set rather than a string-range comparison
+    // (event.key >= "1" && event.key <= "9"), which is technically correct
+    // but non-obvious. The set documents intent and matches the nine
+    // mod+1..mod+9 combos registered in AppLayout one-for-one.
+    const DIGIT_KEYS = new Set(["1", "2", "3", "4", "5", "6", "7", "8", "9"]);
+
+    term.attachCustomKeyEventHandler((event) => {
+      if (event.type !== "keydown") return true;
+      const mod = event.metaKey || event.ctrlKey;
+      if (!mod) return true;
+      // Only intercept bare mod+key — reject any extra modifiers so that
+      // mod+Shift+... and mod+Alt+... still reach xterm and the shell.
+      if (event.shiftKey || event.altKey) return true;
+      if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+        return false;
+      }
+      if (DIGIT_KEYS.has(event.key)) {
+        return false;
+      }
+      return true;
+    });
+
     term.open(containerRef.current);
 
     // ── OSC 6800 handler ──────────────────────────────────────────────────────

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -270,8 +270,9 @@ describe("AppLayout — keyboard navigation", () => {
         onRemoveCard={vi.fn()}
         activeId={activeId}
         onActiveIdChange={onActiveIdChange}
-        contexts={{}}
-        onContextChange={vi.fn()}
+        sessionContext={{}}
+        onSessionContextChange={vi.fn()}
+        onSessionContextPatch={vi.fn()}
       />,
     );
     return { ...result, onActiveIdChange, user };

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@xterm/xterm", () => {
       dispose: _vi.fn(),
       onData: _vi.fn().mockReturnValue({ dispose: _vi.fn() }),
       parser: { registerOscHandler: _vi.fn().mockReturnValue({ dispose: _vi.fn() }) },
+      attachCustomKeyEventHandler: _vi.fn(),
     };
   }
   return { Terminal: vi.fn().mockImplementation(MockTerminal) };
@@ -41,6 +42,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 import React from "react";
 import { act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../test-utils/render";
 import { AppLayout } from "./AppLayout";
 import { invoke } from "@tauri-apps/api/core";
@@ -249,6 +251,144 @@ describe("AppLayout", () => {
       if (val instanceof Error) {
         expect(val.message).not.toContain("session already exists");
       }
+    }
+  });
+});
+
+// ── Keyboard navigation integration tests ─────────────────────────────────────
+
+describe("AppLayout — keyboard navigation", () => {
+  const threeCards = [{ id: "A" }, { id: "B" }, { id: "C" }];
+
+  function renderLayout(cards: { id: string }[], activeId: string | null) {
+    const onActiveIdChange = vi.fn();
+    const user = userEvent.setup();
+    const result = renderWithProviders(
+      <AppLayout
+        cards={cards}
+        onAddCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        activeId={activeId}
+        onActiveIdChange={onActiveIdChange}
+        contexts={{}}
+        onContextChange={vi.fn()}
+      />,
+    );
+    return { ...result, onActiveIdChange, user };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _clearSpawnChainForTesting();
+    (invoke as unknown as AnyMock).mockResolvedValue(1);
+    globalThis.ResizeObserver = vi.fn().mockImplementation(function () {
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+    }) as unknown as typeof ResizeObserver;
+  });
+
+  it("cycle next (mod+ArrowRight) from middle card activates next card", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "B");
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+    });
+    expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+    expect(onActiveIdChange).toHaveBeenCalledWith("C");
+  });
+
+  it("cycle previous (mod+ArrowLeft) from middle card activates previous card", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "B");
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowLeft}{/Meta}");
+    });
+    expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+    expect(onActiveIdChange).toHaveBeenCalledWith("A");
+  });
+
+  it("cycle next wraps from last card to first card", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "C");
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+    });
+    expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+    expect(onActiveIdChange).toHaveBeenCalledWith("A");
+  });
+
+  it("cycle previous wraps from first card to last card", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "A");
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowLeft}{/Meta}");
+    });
+    expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+    expect(onActiveIdChange).toHaveBeenCalledWith("C");
+  });
+
+  it("numeric jump mod+1 activates first card", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "B");
+    await act(async () => {
+      await user.keyboard("{Meta>}1{/Meta}");
+    });
+    expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+    expect(onActiveIdChange).toHaveBeenCalledWith("A");
+  });
+
+  it("numeric jump mod+3 activates third card", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "A");
+    await act(async () => {
+      await user.keyboard("{Meta>}3{/Meta}");
+    });
+    expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+    expect(onActiveIdChange).toHaveBeenCalledWith("C");
+  });
+
+  it("numeric jump beyond range is a no-op", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "A");
+    await act(async () => {
+      await user.keyboard("{Meta>}4{/Meta}");
+    });
+    expect(onActiveIdChange).not.toHaveBeenCalled();
+  });
+
+  it("cycle is a no-op with one card", async () => {
+    const { onActiveIdChange, user } = renderLayout([{ id: "A" }], "A");
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+    });
+    expect(onActiveIdChange).not.toHaveBeenCalled();
+  });
+
+  it("cycle is a no-op with zero cards", async () => {
+    const { onActiveIdChange, user } = renderLayout([], null);
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+    });
+    expect(onActiveIdChange).not.toHaveBeenCalled();
+  });
+
+  it("mod+0 is unhandled (regression guard)", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "A");
+    await act(async () => {
+      await user.keyboard("{Meta>}0{/Meta}");
+    });
+    expect(onActiveIdChange).not.toHaveBeenCalled();
+  });
+
+  it("hotkey fires while a textarea is focused (tagsToIgnore: [] override)", async () => {
+    const { onActiveIdChange, user } = renderLayout(threeCards, "B");
+
+    const textarea = document.createElement("textarea");
+    textarea.setAttribute("data-testid", "probe-textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    try {
+      await act(async () => {
+        await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+      });
+      expect(onActiveIdChange).toHaveBeenCalledTimes(1);
+      expect(onActiveIdChange).toHaveBeenCalledWith("C");
+    } finally {
+      document.body.removeChild(textarea);
     }
   });
 });

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { AppShell, Burger, Group, Tabs, Text, Title } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
+import { useDisclosure, useHotkeys } from "@mantine/hooks";
+import { getCycleTargetId, getNumericTargetId } from "./tabNavigation";
 import type { Card } from "../../types/card";
 import type { SessionContext } from "../../types/session";
 import { NavBar } from "./NavBar";
@@ -30,6 +31,55 @@ export function AppLayout({
   onSessionContextPatch,
 }: AppLayoutProps) {
   const [opened, { toggle }] = useDisclosure(true);
+
+  const activate = (targetId: string | null) => {
+    if (targetId !== null) {
+      onActiveIdChange(targetId);
+    }
+  };
+
+  // useHotkeys registers a single document-level listener via
+  // useEffect(..., []) and uses useEffectEvent to keep the hotkeys array
+  // current — no per-render rebind occurs. The listener attaches at
+  // document.documentElement (not window/document).
+  //
+  // The second positional argument (tagsToIgnore) is explicitly set to []
+  // (overriding Mantine's default of ["INPUT","TEXTAREA","SELECT"]).
+  // Mantine's internal shouldFireEvent gates on event.target.tagName and
+  // would otherwise short-circuit when focus is in xterm's
+  // xterm-helper-textarea (the hidden HTMLTextAreaElement xterm focuses
+  // whenever the user clicks into the terminal viewport), silently
+  // breaking the central use case ("hotkeys work when focus is in the
+  // terminal"). These eleven combos are global app-navigation shortcuts,
+  // not text-entry combos — Cmd+ArrowLeft/Right and Cmd+1..Cmd+9 do not
+  // collide with any standard typing flow, so blocking them in inputs
+  // would surprise users.
+  //
+  // Note on event.preventDefault(): Mantine's useHotkeys unconditionally
+  // calls event.preventDefault() on every matched hotkey, regardless of
+  // whether the handler does anything observable. This means even when
+  // getCycleTargetId returns null (e.g. cards.length < 2, or activeId
+  // not in cards) and `activate` is a no-op, Cmd+ArrowLeft's default
+  // WebView back-navigation is still suppressed. This is intentional:
+  // we never want Cmd+ArrowLeft to trigger WebView history navigation
+  // inside the shell, so suppressing the default in the no-op case is
+  // the correct behaviour, not a leak.
+  useHotkeys(
+    [
+      ["mod+ArrowLeft", () => activate(getCycleTargetId(cards, activeId, -1))],
+      ["mod+ArrowRight", () => activate(getCycleTargetId(cards, activeId, +1))],
+      ["mod+1", () => activate(getNumericTargetId(cards, 1))],
+      ["mod+2", () => activate(getNumericTargetId(cards, 2))],
+      ["mod+3", () => activate(getNumericTargetId(cards, 3))],
+      ["mod+4", () => activate(getNumericTargetId(cards, 4))],
+      ["mod+5", () => activate(getNumericTargetId(cards, 5))],
+      ["mod+6", () => activate(getNumericTargetId(cards, 6))],
+      ["mod+7", () => activate(getNumericTargetId(cards, 7))],
+      ["mod+8", () => activate(getNumericTargetId(cards, 8))],
+      ["mod+9", () => activate(getNumericTargetId(cards, 9))],
+    ],
+    [],
+  );
 
   return (
     // Tabs wraps the entire AppShell so that Tabs.List (inside AppShell.Navbar)

--- a/src/components/layout/tabNavigation.test.ts
+++ b/src/components/layout/tabNavigation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { getCycleTargetId, getNumericTargetId } from "./tabNavigation";
+
+const A = { id: "A" };
+const B = { id: "B" };
+const C = { id: "C" };
+
+describe("getCycleTargetId", () => {
+  it("returns null for empty cards array", () => {
+    expect(getCycleTargetId([], "A", 1)).toBeNull();
+    expect(getCycleTargetId([], "A", -1)).toBeNull();
+  });
+
+  it("returns null for one-card array", () => {
+    expect(getCycleTargetId([A], "A", 1)).toBeNull();
+    expect(getCycleTargetId([A], "A", -1)).toBeNull();
+  });
+
+  it("returns next card from middle (direction +1)", () => {
+    expect(getCycleTargetId([A, B, C], "B", 1)).toBe("C");
+  });
+
+  it("returns previous card from middle (direction -1)", () => {
+    expect(getCycleTargetId([A, B, C], "B", -1)).toBe("A");
+  });
+
+  it("wraps from last card to first (direction +1)", () => {
+    expect(getCycleTargetId([A, B, C], "C", 1)).toBe("A");
+  });
+
+  it("wraps from first card to last (direction -1)", () => {
+    expect(getCycleTargetId([A, B, C], "A", -1)).toBe("C");
+  });
+
+  it("returns null when activeId is null", () => {
+    expect(getCycleTargetId([A, B, C], null, 1)).toBeNull();
+  });
+
+  it("returns null when activeId is not found in cards (stale id)", () => {
+    expect(getCycleTargetId([A, B, C], "Z", 1)).toBeNull();
+  });
+});
+
+describe("getNumericTargetId", () => {
+  it("returns null for empty cards at position 1", () => {
+    expect(getNumericTargetId([], 1)).toBeNull();
+  });
+
+  it("returns first card at position 1", () => {
+    expect(getNumericTargetId([A, B, C], 1)).toBe("A");
+  });
+
+  it("returns third card at position 3", () => {
+    expect(getNumericTargetId([A, B, C], 3)).toBe("C");
+  });
+
+  it("returns null when position exceeds cards.length", () => {
+    expect(getNumericTargetId([A, B, C], 4)).toBeNull();
+  });
+
+  it("returns ninth card at position 9 with nine cards", () => {
+    const nineCards = [
+      { id: "1" },
+      { id: "2" },
+      { id: "3" },
+      { id: "4" },
+      { id: "5" },
+      { id: "6" },
+      { id: "7" },
+      { id: "8" },
+      { id: "9" },
+    ];
+    expect(getNumericTargetId(nineCards, 9)).toBe("9");
+  });
+
+  it("returns null at position 9 with only five cards", () => {
+    const fiveCards = [{ id: "1" }, { id: "2" }, { id: "3" }, { id: "4" }, { id: "5" }];
+    expect(getNumericTargetId(fiveCards, 9)).toBeNull();
+  });
+});

--- a/src/components/layout/tabNavigation.ts
+++ b/src/components/layout/tabNavigation.ts
@@ -1,0 +1,35 @@
+import type { Card } from "../../types/card";
+
+/**
+ * Returns the id of the card that should become active when the user
+ * presses mod+ArrowLeft or mod+ArrowRight. Wraps around at the
+ * boundaries. Returns null when cycling is not possible (no cards) or
+ * pointless (one card, or activeId not found in cards).
+ *
+ * direction: -1 for previous (mod+ArrowLeft), +1 for next (mod+ArrowRight).
+ */
+export function getCycleTargetId(
+  cards: Card[],
+  activeId: string | null,
+  direction: -1 | 1,
+): string | null {
+  if (cards.length < 2) return null;
+  if (activeId === null) return null;
+  const currentIndex = cards.findIndex((c) => c.id === activeId);
+  if (currentIndex === -1) return null;
+  const nextIndex = (currentIndex + direction + cards.length) % cards.length;
+  return cards[nextIndex].id;
+}
+
+/**
+ * Returns the id of the card at the given 1-based position, or null when
+ * the position exceeds cards.length or cards is empty.
+ *
+ * position: integer in [1, 9]; behaviour for values outside this range is
+ * undefined (the caller is the hotkey registration which only passes
+ * 1..9).
+ */
+export function getNumericTargetId(cards: Card[], position: number): string | null {
+  if (position < 1 || position > cards.length) return null;
+  return cards[position - 1].id;
+}


### PR DESCRIPTION
Adds 11 global keyboard shortcuts for switching between terminal tabs without reaching for the mouse: \`Cmd/Ctrl+←/→\` cycles to the previous/next tab with wrap-around, and \`Cmd/Ctrl+1–9\` jumps directly to a tab by position. The shortcuts work whether focus is in the terminal viewport or the sidebar, and shift/alt-prefixed variants (e.g. \`Ctrl+Shift+1\` used by tmux) are intentionally passed through to the shell unchanged.

Closes #29