### PR TITLE
fix(settings): surface inline error in modal when save fails

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -73,6 +73,7 @@ vi.mock("./settings/SettingsContext", () => ({
       terminal: { fontSize: 13 },
     },
     updateSettings: vi.fn().mockResolvedValue(undefined),
+    saveError: null,
   }),
 }));
 

--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../settings/SettingsContext", () => ({
       terminal: mockTerminalSettings,
     },
     updateSettings: vi.fn().mockResolvedValue(undefined),
+    saveError: null,
   }),
 }));
 

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -30,6 +30,7 @@ vi.mock("../../settings/SettingsContext", () => ({
       terminal: { fontSize: 13 },
     },
     updateSettings: vi.fn().mockResolvedValue(undefined),
+    saveError: null,
   }),
 }));
 

--- a/src/components/settings/SettingsModal.test.tsx
+++ b/src/components/settings/SettingsModal.test.tsx
@@ -6,20 +6,23 @@
 
 import { vi } from "vitest";
 
-const { updateSettingsSpy, mockSettingsStore } = vi.hoisted(() => {
+const { updateSettingsSpy, mockSettingsStore, mockSaveError } = vi.hoisted(() => {
   const _store = {
     version: 1 as const,
     colorScheme: "auto" as "light" | "dark" | "auto",
     terminal: { fontSize: 13 },
   };
   const _spy = vi.fn().mockResolvedValue(undefined);
-  return { updateSettingsSpy: _spy, mockSettingsStore: _store };
+  // saveError is re-read on each useSettings() invocation; tests should set it before the render under test.
+  const _err = { current: null as Error | null };
+  return { updateSettingsSpy: _spy, mockSettingsStore: _store, mockSaveError: _err };
 });
 
 vi.mock("../../settings/SettingsContext", () => ({
   useSettings: () => ({
     settings: mockSettingsStore,
     updateSettings: updateSettingsSpy,
+    saveError: mockSaveError.current,
   }),
 }));
 
@@ -49,6 +52,7 @@ describe("SettingsModal", () => {
     vi.clearAllMocks();
     mockSettingsStore.colorScheme = "auto";
     mockSettingsStore.terminal.fontSize = 13;
+    mockSaveError.current = null;
   });
 
   it("renders the Color scheme Select with three options (Light, Dark, Auto)", async () => {
@@ -154,5 +158,23 @@ describe("SettingsModal", () => {
     expect(isFinite(NaN)).toBe(false);
     // On fresh render with no interaction, updateSettings is not called
     expect(updateSettingsSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders an inline Alert with the error message when saveError is non-null", () => {
+    mockSaveError.current = new Error("disk full");
+
+    renderWithProviders(<SettingsModal opened={true} onClose={vi.fn()} />);
+
+    expect(within(document.body).getByTestId("settings-save-error")).toBeInTheDocument();
+    expect(within(document.body).getByTestId("settings-save-error").textContent).toContain(
+      "disk full",
+    );
+  });
+
+  it("does NOT render the inline Alert when saveError is null", () => {
+    // mockSaveError.current is null from beforeEach reset
+    renderWithProviders(<SettingsModal opened={true} onClose={vi.fn()} />);
+
+    expect(within(document.body).queryByTestId("settings-save-error")).toBeNull();
   });
 });

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, NumberInput, Select, Stack } from "@mantine/core";
+import { Alert, Modal, NumberInput, Select, Stack } from "@mantine/core";
 import { useSettings } from "../../settings/SettingsContext";
 
 interface SettingsModalProps {
@@ -7,11 +7,16 @@ interface SettingsModalProps {
 }
 
 export function SettingsModal({ opened, onClose }: SettingsModalProps) {
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, saveError } = useSettings();
 
   return (
     <Modal opened={opened} onClose={onClose} title="Settings" size="md">
       <Stack>
+        {saveError !== null && (
+          <Alert color="red" title="Failed to save settings" data-testid="settings-save-error">
+            {saveError.message}
+          </Alert>
+        )}
         <Select
           label="Color scheme"
           value={settings.colorScheme}
@@ -22,7 +27,9 @@ export function SettingsModal({ opened, onClose }: SettingsModalProps) {
           ]}
           onChange={(value) => {
             if (value === "light" || value === "dark" || value === "auto") {
-              void updateSettings({ colorScheme: value });
+              updateSettings({ colorScheme: value }).catch((err) => {
+                console.error("[SettingsModal] updateSettings rejected:", err);
+              });
             }
           }}
         />
@@ -36,7 +43,9 @@ export function SettingsModal({ opened, onClose }: SettingsModalProps) {
             // Reject empty string and non-finite values — do NOT call updateSettings
             // with NaN or '' as these would corrupt the persisted settings.
             if (typeof value === "number" && isFinite(value)) {
-              void updateSettings({ terminal: { fontSize: value } });
+              updateSettings({ terminal: { fontSize: value } }).catch((err) => {
+                console.error("[SettingsModal] updateSettings rejected:", err);
+              });
             }
           }}
         />

--- a/src/settings/SettingsContext.test.tsx
+++ b/src/settings/SettingsContext.test.tsx
@@ -155,10 +155,11 @@ describe("SettingsProvider", () => {
     const { SettingsProvider, useSettings } = await import("./SettingsContext");
 
     function Consumer() {
-      const { settings, updateSettings } = useSettings();
+      const { settings, updateSettings, saveError } = useSettings();
       return (
         <div>
           <span data-testid="scheme">{settings.colorScheme}</span>
+          {saveError !== null && <span data-testid="save-error">{saveError.message}</span>}
           <button
             onClick={() => {
               void updateSettings({ colorScheme: "dark" }).catch(() => {});
@@ -186,6 +187,77 @@ describe("SettingsProvider", () => {
     await waitFor(() => {
       expect(screen.getByTestId("scheme").textContent).toBe("auto");
     });
+
+    // saveError should be surfaced with the thrown message
+    await waitFor(() => {
+      expect(screen.getByTestId("save-error").textContent).toBe("disk full");
+    });
+  });
+
+  it("updateSettings clears saveError on the next successful save", async () => {
+    const saveSettingsMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValueOnce(undefined);
+
+    vi.doMock("./persistence", () => ({
+      loadSettings: vi.fn(() => Promise.resolve(DEFAULT_SETTINGS)),
+      saveSettings: saveSettingsMock,
+    }));
+
+    const { SettingsProvider, useSettings } = await import("./SettingsContext");
+
+    function Consumer() {
+      const { settings, updateSettings, saveError } = useSettings();
+      return (
+        <div>
+          <span data-testid="scheme">{settings.colorScheme}</span>
+          {saveError !== null && <span data-testid="save-error">{saveError.message}</span>}
+          <button
+            onClick={() => {
+              void updateSettings({ colorScheme: "dark" }).catch(() => {});
+            }}
+          >
+            Set dark
+          </button>
+          <button
+            onClick={() => {
+              void updateSettings({ colorScheme: "light" }).catch(() => {});
+            }}
+          >
+            Set light
+          </button>
+        </div>
+      );
+    }
+
+    await act(async () => {
+      render(
+        <SettingsProvider>
+          <Consumer />
+        </SettingsProvider>,
+      );
+    });
+
+    // First click: save fails → saveError is set, scheme stays "auto"
+    await act(async () => {
+      screen.getByText("Set dark").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("save-error").textContent).toBe("disk full");
+    });
+    expect(screen.getByTestId("scheme").textContent).toBe("auto");
+
+    // Second click: save succeeds → saveError is cleared, scheme updates
+    await act(async () => {
+      screen.getByText("Set light").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scheme").textContent).toBe("light");
+    });
+    expect(screen.queryByTestId("save-error")).toBeNull();
   });
 
   it("useSettings throws when called outside a provider", async () => {

--- a/src/settings/SettingsContext.tsx
+++ b/src/settings/SettingsContext.tsx
@@ -30,6 +30,7 @@ type DeepPartial<T> = {
 interface SettingsContextValue {
   settings: Settings;
   updateSettings: (patch: DeepPartial<Settings>) => Promise<void>;
+  saveError: Error | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -59,6 +60,7 @@ const SettingsContext = createContext<SettingsContextValue | null>(null);
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [saveError, setSaveError] = useState<Error | null>(null);
 
   useEffect(() => {
     void loadSettings().then((loaded) => {
@@ -70,17 +72,25 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     async (patch: DeepPartial<Settings>): Promise<void> => {
       if (settings === null) return;
       const merged = deepMergeSettings(settings, patch);
-      // Only update React state on successful persistence — a write failure must
-      // not leave the UI showing settings that are not on disk.
-      await saveSettings(merged);
-      setSettings(merged);
+      // Capture the error so consumers (e.g. SettingsModal) can render an inline
+      // message; re-throw so awaiting callers still observe the rejection.
+      try {
+        // Only update React state on successful persistence — a write failure must
+        // not leave the UI showing settings that are not on disk.
+        await saveSettings(merged);
+        setSaveError(null);
+        setSettings(merged);
+      } catch (err) {
+        setSaveError(err instanceof Error ? err : new Error(String(err)));
+        throw err;
+      }
     },
     [settings],
   );
 
   const contextValue = useMemo(
-    () => (settings === null ? null : { settings, updateSettings }),
-    [settings, updateSettings],
+    () => (settings === null ? null : { settings, updateSettings, saveError }),
+    [settings, updateSettings, saveError],
   );
 
   // Return null until loadSettings resolves — this prevents any consumer from


### PR DESCRIPTION
Settings modal dropdowns were silently reverting when the Tauri filesystem write threw an error — saveSettings failures were swallowed by a void discard at the call site, and setSettings was never called.

The "UI must match disk" invariant (state only updated on successful save) was an intentional design choice, so this fix preserves it. Instead of optimistic updates, a saveError state is now exposed via SettingsContext. SettingsModal renders a Mantine Alert as the first child of its Stack when saveError is non-null, giving the user a clear explanation of why the dropdown reverted.