### PR TITLE
feat(sidecar): add Python sidecar with dungeon-card lifecycle

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -2,6 +2,8 @@
 
 ```
 ai-dungeon/
+├── python/
+│   └── sidecar.py        # Hello-world Python sidecar: prints a startup line then sleeps. Spawned by the Rust backend on the first card open; killed on the last card close. Dev-mode only — no production bundling.
 ├── public/
 │   └── fonts/            # Vendored MesloLGS NF TTF faces (see MesloLGS NF section below)
 │       ├── MesloLGS NF Regular.ttf
@@ -15,17 +17,19 @@ ai-dungeon/
 │   │   └── fonts.css # @font-face declarations for MesloLGS NF (all four faces)
 │   ├── App.tsx       # Root component — useReducer for cards + activeId; owns tab state
 │   ├── types/
-│   │   ├── card.ts               # Card type ({ id: string })
+│   │   ├── card.ts               # Card type ({ id: string }) + isDungeonCard() predicate
 │   │   ├── session.ts            # SessionContext (OSC 6800) and ShellContext (OSC 7/7337) interfaces; all values are UNTRUSTED. branch and repo are optional on both types (cleared by empty OSC 7337).
 │   │   ├── sessionPayload.ts     # parseSessionContextPayload() / parseOsc7Payload() / parseOsc7337Payload() — validate all inbound OSC payloads before they enter app state. Single audit entry point for OSC 6800, OSC 7, and OSC 7337.
 │   │   └── sessionPayload.test.ts
 │   └── components/
 │       ├── Terminal/
-│       │   ├── Terminal.tsx   # xterm.js wrapper — accepts sessionId prop; OSC 6800, OSC 7, and OSC 7337 handlers; PTY IPC, FitAddon, WebFontsAddon, base64 I/O; module-level per-sid spawn-chain serialises pty_spawn/pty_kill to prevent StrictMode remount races; awaits loadFonts() before term.open()
-│       │   ├── index.ts       # Barrel export
+│       │   ├── Terminal.tsx          # xterm.js wrapper — accepts sessionId prop; OSC 6800, OSC 7, and OSC 7337 handlers; PTY IPC, FitAddon, WebFontsAddon, base64 I/O; module-level per-sid spawn-chain serialises pty_spawn/pty_kill to prevent StrictMode remount races; awaits loadFonts() before term.open()
+│       │   ├── useDungeonSidecar.ts  # Hook: calls dungeon_open on mount and dungeon_close on unmount; promise-chain serialisation prevents StrictMode close-before-open races
+│       │   ├── index.ts              # Barrel export
 │       │   └── Terminal.test.tsx
 │       └── layout/
-│           ├── AppLayout.tsx          # Mantine Tabs + AppShell — threads sessionContext + shellContext + their change callbacks to NavBar and Terminal
+│           ├── AppLayout.tsx          # Mantine Tabs + AppShell — renders one CardPanel per card; threads sessionContext + shellContext callbacks to NavBar
+│           ├── CardPanel.tsx          # Per-card panel component: hosts useDungeonSidecar and renders the Terminal inside a Tabs.Panel
 │           ├── NavBar.tsx             # Sidebar — passes per-card sessionContext and shellContext to each SessionCard
 │           ├── SessionCard.tsx        # 3-row tab label: slug + close button, repo:branch • path-tail, PR/Issue badges; rendering precedence: sessionContext ?? shellContext ?? mock
 │           ├── SessionCard.test.tsx   # Unit tests for SessionCard (two-slot rendering + legacy cases)
@@ -35,7 +39,8 @@ ai-dungeon/
 │   ├── src/
 │   │   ├── main.rs   # Binary entry point
 │   │   ├── lib.rs    # Library crate (command handlers)
-│   │   └── pty.rs    # PTY session management (spawn/write/resize/kill commands); generation tokens + duplicate-ID rejection prevent orphaned sessions on rapid remount; exports TERM_PROGRAM=ai-dungeon for child-process self-identification; exports LC_ALL with UTF-8 locale on Unix; bash/zsh sessions additionally receive `__ai_dungeon_emit_ctx` via per-session shell-startup-file injection (ZDOTDIR override for zsh, --rcfile for bash) so the hook is wired before ZLE binds the keyboard
+│   │   ├── pty.rs    # PTY session management (spawn/write/resize/kill commands); generation tokens + duplicate-ID rejection prevent orphaned sessions on rapid remount; exports TERM_PROGRAM=ai-dungeon for child-process self-identification; exports LC_ALL with UTF-8 locale on Unix; bash/zsh sessions additionally receive `__ai_dungeon_emit_ctx` via per-session shell-startup-file injection (ZDOTDIR override for zsh, --rcfile for bash) so the hook is wired before ZLE binds the keyboard
+│   │   └── dungeon.rs  # Python sidecar lifecycle — DungeonState (Mutex-protected counter + Child slot), dungeon_open / dungeon_close Tauri commands, testable inner functions
 │   ├── capabilities/ # Tauri permission grants
 │   ├── icons/        # App icons (all sizes)
 │   ├── Cargo.toml
@@ -81,6 +86,47 @@ imperfectly in browser-based terminals due to upstream xterm.js limitations
 unrelated to font loading. See the xterm.js issue tracker for the current status.
 
 For historical context and the full design rationale, see issue #32.
+
+## Python Sidecar Lifecycle
+
+A single Python sidecar process (`python/sidecar.py`) is spawned when the first session card opens and killed when the last card closes. The sidecar is a process-wide singleton: opening additional cards never spawns more than one process, and closing some-but-not-all cards leaves it running.
+
+### Why a reference-counted singleton?
+
+Dungeon cards will eventually be backed by a long-running Python process. Tying the sidecar lifetime to "any card is open" is the minimal, verifiable foundation: it proves the spawn/kill path end-to-end before IPC or real functionality is added. A reference-counted design means the resource is held exactly as long as it is needed, and the lifecycle is symmetric — every `open` is paired with a `close`.
+
+### Rust layer (`src-tauri/src/dungeon.rs`)
+
+`DungeonState` holds a `Mutex<DungeonInner>` containing an `open_count: u32` and an `Option<Child>`. Two Tauri commands drive it:
+
+- `dungeon_open` — increments `open_count`. On the 0 → 1 transition, spawns `python3 python/sidecar.py` — but only in debug builds (`#[cfg(debug_assertions)]`). Release builds skip the spawn and emit a log line instead. The count is incremented even when spawn fails, preserving the open/close symmetry: a subsequent `dungeon_close` will decrement cleanly without underflowing.
+- `dungeon_close` — decrements `open_count`. On the N → 1 → 0 transition, takes the `Child` out of the slot, calls `kill()`, and calls `wait()` to reap the process and avoid zombies on Unix. Calling `dungeon_close` when `open_count` is already 0 is a no-op with a logged warning.
+
+The script path is resolved at compile time via `env!("CARGO_MANIFEST_DIR")` joined with `../python/sidecar.py`, so `cargo tauri dev` works on a fresh checkout without configuration. Spawn failures surface as `eprintln!` log lines; they do not return an error to the frontend and do not block card creation.
+
+The inner logic is split into `dungeon_open_with_spawner` and `dungeon_close_inner` (functions that accept a `spawner` closure and a `&mut DungeonInner` respectively) so unit tests can inject a fast-exiting `/bin/sh -c "sleep 1"` child instead of requiring Python on CI.
+
+### Frontend layer
+
+**`src/types/card.ts` — `isDungeonCard(card)`**
+
+The single predicate that decides whether a card participates in the sidecar lifecycle. Today it returns `true` for every card. When a `Card.type` field lands, this becomes `card.type === "dungeon"` — a one-line edit. The predicate must not be inlined at call sites; all consumers import it by name.
+
+**`src/components/Terminal/useDungeonSidecar.ts`**
+
+React hook mounted once per card (from `CardPanel`). On mount it calls `dungeon_open`; its cleanup calls `dungeon_close`. Both calls are chained on a `chainRef` promise so that React 19 StrictMode's rapid mount → unmount → remount sequence always delivers open before close at the Rust backend — the same serialisation pattern used by `Terminal.tsx` for `pty_spawn`/`pty_kill`. Invoke rejections are caught and logged to `console.warn`; they do not throw inside the effect.
+
+**`src/components/layout/CardPanel.tsx`**
+
+Thin per-card component extracted from `AppLayout`. Hosts `useDungeonSidecar` (hooks cannot be called inside `Array.map`) and renders the `Terminal` inside its `Tabs.Panel`. `AppLayout` maps `cards` to `<CardPanel>` elements.
+
+### Constraints and non-goals (v1)
+
+- No IPC between Rust and the Python process (no stdin pipe, no port, no message bus).
+- No user-visible UI for sidecar state (failures go to `eprintln!` only).
+- Debug builds only — the spawn call is gated on `#[cfg(debug_assertions)]`. Release builds log a message and skip spawn entirely. The script path uses a compile-time `CARGO_MANIFEST_DIR` reference that only works in dev mode.
+- `python3`-only — there is no `python` fallback. The interpreter must be on `PATH` as `python3`.
+- Crash recovery is out of scope: if the sidecar dies while cards are open, the stale `Child` handle remains until the last card closes, at which point `kill()` is called (idempotent) and a fresh process is spawned on the next 0 → 1 transition.
 
 ## OSC Session-Context Flow (6800 / 7 / 7337)
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -1,12 +1,13 @@
 # Tech Stack
 
-| Layer           | Technology                                                                          |
-| --------------- | ----------------------------------------------------------------------------------- |
-| Desktop shell   | [Tauri v2](https://v2.tauri.app/)                                                   |
-| Frontend        | React 19 + TypeScript                                                               |
-| UI library      | [Mantine v9](https://mantine.dev/)                                                  |
-| Icons           | [@tabler/icons-react v3](https://tabler.io/icons)                                   |
-| Terminal        | [@xterm/xterm](https://xtermjs.org/) v6 + @xterm/addon-fit + @xterm/addon-web-fonts |
-| Bundler         | Vite 8 (PostCSS via `postcss.config.cjs`)                                           |
-| Package manager | pnpm                                                                                |
-| Backend         | Rust (Cargo) + [portable-pty](https://docs.rs/portable-pty)                         |
+| Layer           | Technology                                                                                |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| Desktop shell   | [Tauri v2](https://v2.tauri.app/)                                                         |
+| Frontend        | React 19 + TypeScript                                                                     |
+| UI library      | [Mantine v9](https://mantine.dev/)                                                        |
+| Icons           | [@tabler/icons-react v3](https://tabler.io/icons)                                         |
+| Terminal        | [@xterm/xterm](https://xtermjs.org/) v6 + @xterm/addon-fit + @xterm/addon-web-fonts       |
+| Bundler         | Vite 8 (PostCSS via `postcss.config.cjs`)                                                 |
+| Package manager | pnpm                                                                                      |
+| Backend         | Rust (Cargo) + [portable-pty](https://docs.rs/portable-pty)                               |
+| Sidecar         | Python 3 (stdlib only) — `python3` on `PATH`; dev builds only (release builds skip spawn) |

--- a/python/sidecar.py
+++ b/python/sidecar.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# NOTE (F-7): The Rust parent terminates this sidecar via Child::kill(), which
+# sends SIGKILL on Unix. The SIGTERM handler below exists only for manual
+# `kill -TERM <pid>` testing. SIGKILL cannot be caught or handled — this script
+# will be terminated abruptly in production; no cleanup runs on SIGKILL.
+import sys
+import time
+import signal
+
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+print("[ai-dungeon-sidecar] hello, world", flush=True)
+
+while True:
+    time.sleep(60)

--- a/src-tauri/src/dungeon.rs
+++ b/src-tauri/src/dungeon.rs
@@ -1,0 +1,255 @@
+use std::process::{Child, Command};
+use std::sync::Mutex;
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+pub struct DungeonInner {
+    /// Number of cards that have called dungeon_open without a matching dungeon_close.
+    pub open_count: u32,
+    // NOTE (non-goal): Crash recovery (sidecar dying while cards are open) is out of
+    // scope for v1. If the sidecar dies externally, `child` remains `Some` with a
+    // stale handle until the last card closes. The next 0→1 transition will then
+    // spawn a fresh process.
+    pub child: Option<Child>,
+}
+
+#[derive(Default)]
+pub struct DungeonState {
+    inner: Mutex<DungeonInner>,
+}
+
+impl Default for DungeonInner {
+    fn default() -> Self {
+        DungeonInner {
+            open_count: 0,
+            child: None,
+        }
+    }
+}
+
+// ── Path resolution ───────────────────────────────────────────────────────────
+
+// NOTE (dev-only): path is resolved via CARGO_MANIFEST_DIR, which is baked in at compile time.
+// This resolves correctly in `cargo tauri dev` but NOT in production bundles.
+// Production packaging (bundle.resources + PathResolver) is tracked in open-questions.md.
+fn resolve_sidecar_script_path() -> std::path::PathBuf {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("../python/sidecar.py")
+}
+
+// ── Spawn helper ──────────────────────────────────────────────────────────────
+
+fn spawn_sidecar() -> Result<Child, String> {
+    Command::new("python3")
+        .arg(resolve_sidecar_script_path())
+        .spawn()
+        .map_err(|e| format!("failed to spawn sidecar: {e}"))
+}
+
+// ── Testable inner logic ──────────────────────────────────────────────────────
+
+/// Open the dungeon sidecar for a new card.
+///
+/// Increments `open_count`. When transitioning from 0→1, calls `spawner` to
+/// start the sidecar process.
+///
+/// NOTE: `open_count` is incremented even when the spawner fails. This preserves
+/// the symmetry invariant: every successful `dungeon_open` call must be paired
+/// with exactly one `dungeon_close` call. If the caller skipped incrementing on
+/// spawn failure, a subsequent `dungeon_close` would underflow the counter.
+/// When the count eventually reaches 0 again, `child` will be `None` and
+/// dungeon_close will skip the kill+wait step cleanly.
+pub(crate) fn dungeon_open_with_spawner<F>(
+    inner: &mut DungeonInner,
+    spawner: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<Child, String>,
+{
+    inner.open_count += 1;
+
+    if inner.open_count == 1 {
+        // First card: spawn the sidecar (debug builds only).
+        #[cfg(debug_assertions)]
+        match spawner() {
+            Ok(child) => {
+                inner.child = Some(child);
+            }
+            Err(e) => {
+                // Spawn failed — child stays None. Count is already incremented.
+                // The close call will skip kill+wait (child is None) and decrement.
+                eprintln!("[ai-dungeon] dungeon sidecar spawn failed: {e}");
+            }
+        }
+        #[cfg(not(debug_assertions))]
+        eprintln!("[ai-dungeon] sidecar: not available in release builds");
+    }
+
+    Ok(())
+}
+
+/// Close the dungeon sidecar for a card going away.
+///
+/// Decrements `open_count`. When reaching 0, kills and waits on the sidecar
+/// process (if one was successfully spawned). Clamps at zero.
+pub(crate) fn dungeon_close_inner(inner: &mut DungeonInner) -> Result<(), String> {
+    if inner.open_count == 0 {
+        eprintln!("[ai-dungeon] dungeon_close called with open_count already 0 — ignoring");
+        return Ok(());
+    }
+
+    inner.open_count -= 1;
+
+    if inner.open_count == 0 {
+        if let Some(mut child) = inner.child.take() {
+            let _ = child.kill();
+            // Reap the child to avoid zombie processes on Unix (POSIX waitpid semantics).
+            let _ = child.wait();
+        }
+    }
+
+    Ok(())
+}
+
+// ── Tauri commands ────────────────────────────────────────────────────────────
+
+/// Notify the backend that a new dungeon card has mounted.
+///
+/// On the 0→1 transition, spawns the Python sidecar process.
+/// Dispatched off the main thread via `#[tauri::command(async)]`, consistent
+/// with `pty_write`/`pty_resize`.
+#[tauri::command(async)]
+pub async fn dungeon_open(state: tauri::State<'_, DungeonState>) -> Result<(), String> {
+    let mut inner = state
+        .inner
+        .lock()
+        .map_err(|_| "dungeon state mutex poisoned".to_string())?;
+    dungeon_open_with_spawner(&mut inner, spawn_sidecar)
+}
+
+/// Notify the backend that a dungeon card has unmounted.
+///
+/// On the N→0 transition, kills the Python sidecar process.
+/// Dispatched off the main thread via `#[tauri::command(async)]`, consistent
+/// with `pty_write`/`pty_resize`.
+#[tauri::command(async)]
+pub async fn dungeon_close(state: tauri::State<'_, DungeonState>) -> Result<(), String> {
+    let mut inner = state
+        .inner
+        .lock()
+        .map_err(|_| "dungeon state mutex poisoned".to_string())?;
+    dungeon_close_inner(&mut inner)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    /// A spawner that always succeeds by running `sleep 1`.
+    fn ok_spawner() -> Result<Child, String> {
+        Command::new("/bin/sh")
+            .args(["-c", "sleep 1"])
+            .spawn()
+            .map_err(|e| e.to_string())
+    }
+
+    /// A spawner that always fails.
+    fn err_spawner() -> Result<Child, String> {
+        Err("simulated spawn failure".to_string())
+    }
+
+    #[test]
+    #[serial]
+    fn open_then_close_spawns_and_kills_child() {
+        let mut inner = DungeonInner::default();
+
+        dungeon_open_with_spawner(&mut inner, ok_spawner).expect("open must succeed");
+        assert_eq!(inner.open_count, 1, "count must be 1 after open");
+        assert!(inner.child.is_some(), "child must be Some after open");
+
+        dungeon_close_inner(&mut inner).expect("close must succeed");
+        assert_eq!(inner.open_count, 0, "count must be 0 after close");
+        assert!(inner.child.is_none(), "child must be None after close");
+    }
+
+    #[test]
+    #[serial]
+    fn second_open_does_not_spawn() {
+        let mut inner = DungeonInner::default();
+        let mut spawn_count = 0;
+
+        let spawner = || {
+            spawn_count += 1;
+            ok_spawner()
+        };
+        dungeon_open_with_spawner(&mut inner, spawner).expect("first open must succeed");
+
+        let spawner2 = || {
+            spawn_count += 1;
+            ok_spawner()
+        };
+        dungeon_open_with_spawner(&mut inner, spawner2).expect("second open must succeed");
+
+        assert_eq!(spawn_count, 1, "spawner must be called exactly once");
+        assert_eq!(inner.open_count, 2, "count must be 2 after two opens");
+
+        // Cleanup: close twice to kill child.
+        dungeon_close_inner(&mut inner).expect("first close");
+        dungeon_close_inner(&mut inner).expect("second close");
+    }
+
+    #[test]
+    #[serial]
+    fn close_with_other_cards_open_does_not_kill() {
+        let mut inner = DungeonInner::default();
+
+        dungeon_open_with_spawner(&mut inner, ok_spawner).expect("open 1");
+        dungeon_open_with_spawner(&mut inner, ok_spawner).expect("open 2");
+        dungeon_open_with_spawner(&mut inner, ok_spawner).expect("open 3");
+        assert_eq!(inner.open_count, 3);
+
+        dungeon_close_inner(&mut inner).expect("close 1");
+        assert_eq!(inner.open_count, 2, "count must be 2 after one close");
+        assert!(inner.child.is_some(), "child must still be alive at count=2");
+
+        dungeon_close_inner(&mut inner).expect("close 2");
+        assert_eq!(inner.open_count, 1, "count must be 1 after two closes");
+        assert!(inner.child.is_some(), "child must still be alive at count=1");
+
+        dungeon_close_inner(&mut inner).expect("close 3");
+        assert_eq!(inner.open_count, 0, "count must be 0 after three closes");
+        assert!(inner.child.is_none(), "child must be None after last close");
+    }
+
+    #[test]
+    #[serial]
+    fn close_when_count_is_zero_is_noop() {
+        let mut inner = DungeonInner::default();
+        assert_eq!(inner.open_count, 0);
+        assert!(inner.child.is_none());
+
+        let result = dungeon_close_inner(&mut inner);
+        assert!(result.is_ok(), "close on count=0 must return Ok");
+        assert_eq!(inner.open_count, 0, "count must stay 0");
+        assert!(inner.child.is_none(), "child must stay None");
+    }
+
+    #[test]
+    #[serial]
+    fn spawn_failure_still_increments_count() {
+        let mut inner = DungeonInner::default();
+
+        let result = dungeon_open_with_spawner(&mut inner, err_spawner);
+        assert!(result.is_ok(), "open must return Ok even when spawner fails");
+        assert_eq!(inner.open_count, 1, "count must be 1 even after spawn failure");
+        assert!(inner.child.is_none(), "child must be None after spawn failure");
+
+        // close (1→0): must succeed without panic even with child=None
+        let close_result = dungeon_close_inner(&mut inner);
+        assert!(close_result.is_ok(), "close must return Ok");
+        assert_eq!(inner.open_count, 0);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod dungeon;
 mod pty;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -5,11 +6,14 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .manage(pty::PtyState::default())
+        .manage(dungeon::DungeonState::default())
         .invoke_handler(tauri::generate_handler![
             pty::pty_spawn,
             pty::pty_write,
             pty::pty_resize,
             pty::pty_kill,
+            dungeon::dungeon_open,
+            dungeon::dungeon_close,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/Terminal/useDungeonSidecar.test.ts
+++ b/src/components/Terminal/useDungeonSidecar.test.ts
@@ -1,0 +1,107 @@
+// Vitest hoists vi.mock() to module scope; invoke mock must be declared before imports.
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { renderHook, act } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { useDungeonSidecar } from "./useDungeonSidecar";
+import type { Card } from "../../types/card";
+import * as cardModule from "../../types/card";
+
+type AnyMock = ReturnType<typeof vi.fn>;
+
+const mockInvoke = invoke as unknown as AnyMock;
+
+/** Drain all pending microtasks (Promise chain resolutions). */
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    // Multiple rounds to drain chained .then()/.catch() microtasks.
+    // Use sequential awaiting via Array.reduce to avoid the no-await-in-loop lint rule
+    // while preserving the serial microtask-draining semantics.
+    // 5 iterations covers the max promise-chain depth:
+    // open(.then) + catch + close(.then) + catch = 4 hops; 5 gives one extra for safety.
+    await Array.from({ length: 5 }).reduce(
+      (chain) => chain.then(() => Promise.resolve()),
+      Promise.resolve(),
+    );
+  });
+}
+
+describe("useDungeonSidecar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    // Restore any spies (e.g. isDungeonCard, console.warn) so they don't
+    // bleed into subsequent tests.
+    vi.restoreAllMocks();
+  });
+
+  it("calls dungeon_open on mount and dungeon_close on unmount", async () => {
+    const card: Card = { id: "test-card-1" };
+
+    const { unmount } = renderHook(() => useDungeonSidecar(card));
+
+    await flushPromises();
+
+    expect(mockInvoke).toHaveBeenCalledWith("dungeon_open");
+
+    unmount();
+
+    await flushPromises();
+
+    expect(mockInvoke).toHaveBeenCalledWith("dungeon_close");
+  });
+
+  it("does not call invoke when isDungeonCard returns false", async () => {
+    vi.spyOn(cardModule, "isDungeonCard").mockReturnValue(false);
+
+    const card: Card = { id: "non-dungeon-card" };
+    const { unmount } = renderHook(() => useDungeonSidecar(card));
+
+    await flushPromises();
+
+    unmount();
+
+    await flushPromises();
+
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("does not throw and calls console.warn when invoke rejects", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockInvoke.mockRejectedValue(new Error("IPC error"));
+
+    const card: Card = { id: "error-card" };
+
+    renderHook(() => useDungeonSidecar(card));
+
+    await flushPromises();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("dungeon lifecycle"),
+      expect.anything(),
+    );
+  });
+
+  it("calls dungeon_open exactly once when re-rendered with the same card.id", async () => {
+    const card: Card = { id: "stable-id" };
+
+    const { rerender } = renderHook(() => useDungeonSidecar(card));
+
+    await flushPromises();
+
+    // Re-render with the same card object (same id) — effect deps unchanged, no re-fire.
+    rerender();
+
+    await flushPromises();
+
+    const openCalls = (mockInvoke.mock.calls as [string][]).filter(
+      (call) => call[0] === "dungeon_open",
+    );
+    expect(openCalls).toHaveLength(1);
+  });
+});

--- a/src/components/Terminal/useDungeonSidecar.ts
+++ b/src/components/Terminal/useDungeonSidecar.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Card } from "../../types/card";
+import { isDungeonCard } from "../../types/card";
+
+export function useDungeonSidecar(card: Card): void {
+  // Serialization chain: ensures dungeon_close always waits for its paired dungeon_open
+  // to settle before sending its own IPC. This prevents StrictMode's rapid mount/unmount
+  // from delivering close before open at the Rust backend, which would corrupt open_count.
+  // Mirrors the spawnChain pattern in Terminal.tsx.
+  const chainRef = useRef<Promise<void>>(Promise.resolve());
+
+  useEffect(() => {
+    if (!isDungeonCard(card)) return;
+
+    chainRef.current = chainRef.current
+      .then(() => invoke<void>("dungeon_open"))
+      .catch((err) => console.warn("[ai-dungeon] dungeon lifecycle invoke failed:", err));
+
+    const openPromise = chainRef.current;
+
+    return () => {
+      chainRef.current = openPromise
+        .then(() => invoke<void>("dungeon_close"))
+        .catch((err) => console.warn("[ai-dungeon] dungeon lifecycle invoke failed:", err));
+    };
+    // [card.id] is the only dep: the effect's lifecycle is keyed on card identity, not card
+    // content. isDungeonCard currently reads no card properties (returns true for all cards),
+    // so the extra dep is intentional and safe. When Card.type lands, this dep array must be
+    // revisited — isDungeonCard will then read card.type and [card.id, card.type] will be correct.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [card.id]);
+}

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -122,6 +122,14 @@ function installSessionAwareMock(mockInvoke: AnyMock) {
       }
       return undefined;
     }
+    // Dungeon lifecycle commands — handled here for documentary clarity even
+    // though the catch-all below would also return undefined.
+    if (cmd === "dungeon_open") {
+      return undefined;
+    }
+    if (cmd === "dungeon_close") {
+      return undefined;
+    }
     return undefined;
   });
 }
@@ -219,6 +227,13 @@ describe("AppLayout", () => {
       expect(String(arg)).not.toContain("[failed to start shell");
       expect(String(arg)).not.toContain("[pty write failed");
     }
+
+    // F-6: assert dungeon_open was called at least once per rendered card,
+    // proving the hook is actually wired from CardPanel.
+    const dungeonOpenCalls = (mockInvoke.mock.calls as [string, unknown][]).filter(
+      (c) => c[0] === "dungeon_open",
+    );
+    expect(dungeonOpenCalls.length).toBeGreaterThanOrEqual(3);
   });
 
   it("rapid card-add does not produce duplicate-spawn errors at the backend boundary", async () => {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -6,7 +6,7 @@ import { useModifierHeld } from "./useModifierHeld";
 import type { Card } from "../../types/card";
 import type { SessionContext, ShellContext } from "../../types/session";
 import { NavBar } from "./NavBar";
-import { Terminal } from "../Terminal";
+import { CardPanel } from "./CardPanel";
 import { SettingsModal } from "../settings";
 
 // Only consumer is App.tsx. `children` has been removed — AppLayout renders
@@ -163,17 +163,12 @@ export function AppLayout({
             </Text>
           ) : (
             cards.map((card) => (
-              // flex: 1, minHeight: 0 rather than height: 100% because AppShell.Main
-              // is already a flex column — flex children need flex: 1 to fill the
-              // available space, whereas height: 100% does not resolve reliably
-              // against a flex-column parent without an explicit definite height.
-              <Tabs.Panel key={card.id} value={card.id} style={{ flex: 1, minHeight: 0 }}>
-                <Terminal
-                  sessionId={card.id}
-                  onSessionContextChange={(ctx) => onSessionContextChange(card.id, ctx)}
-                  onShellContextChange={(ctx) => onShellContextChange(card.id, ctx)}
-                />
-              </Tabs.Panel>
+              <CardPanel
+                key={card.id}
+                card={card}
+                onSessionContextChange={(ctx) => onSessionContextChange(card.id, ctx)}
+                onShellContextChange={(ctx) => onShellContextChange(card.id, ctx)}
+              />
             ))
           )}
         </AppShell.Main>

--- a/src/components/layout/CardPanel.tsx
+++ b/src/components/layout/CardPanel.tsx
@@ -1,0 +1,29 @@
+import { Tabs } from "@mantine/core";
+import type { Card } from "../../types/card";
+import type { SessionContext, ShellContext } from "../../types/session";
+import { Terminal } from "../Terminal";
+import { useDungeonSidecar } from "../Terminal/useDungeonSidecar";
+
+interface CardPanelProps {
+  card: Card;
+  onSessionContextChange: (ctx: SessionContext) => void;
+  onShellContextChange: (ctx: ShellContext) => void;
+}
+
+export function CardPanel({ card, onSessionContextChange, onShellContextChange }: CardPanelProps) {
+  useDungeonSidecar(card);
+
+  return (
+    // flex: 1, minHeight: 0 rather than height: 100% because AppShell.Main
+    // is already a flex column — flex children need flex: 1 to fill the
+    // available space, whereas height: 100% does not resolve reliably
+    // against a flex-column parent without an explicit definite height.
+    <Tabs.Panel key={card.id} value={card.id} style={{ flex: 1, minHeight: 0 }}>
+      <Terminal
+        sessionId={card.id}
+        onSessionContextChange={onSessionContextChange}
+        onShellContextChange={onShellContextChange}
+      />
+    </Tabs.Panel>
+  );
+}

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -2,3 +2,12 @@
 export interface Card {
   id: string;
 }
+
+/**
+ * Predicate identifying dungeon cards (cards that participate in the Python sidecar lifecycle).
+ * Today every card is a dungeon card. When Card.type lands, this becomes `card.type === "dungeon"` — a one-line edit.
+ * Do NOT inline this predicate at call sites.
+ */
+export function isDungeonCard(_card: Card): boolean {
+  return true;
+}


### PR DESCRIPTION
Adds a singleton Python sidecar process tied to the session-card lifecycle. The sidecar spawns when the first card opens and is killed when the last card closes; opening additional cards does not spawn additional processes.

The lifecycle is implemented as a reference-counted Rust module (`dungeon.rs`) with two async Tauri commands. The frontend `useDungeonSidecar` hook uses a per-card promise-chain to serialize IPC calls and prevent StrictMode double-mount races from corrupting the open count.

The dungeon-card predicate is isolated in `isDungeonCard()` so it is a one-line swap when the parallel `Card.type` work lands. Sidecar spawn is gated behind `#[cfg(debug_assertions)]` — release builds skip spawn cleanly. Initial sidecar is a hello-world mock; IPC and production packaging are deferred.