### PR TITLE
feat(ui): add card type property with terminal and dungeon options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AI coding assistants increasingly run as CLIs that hold long-lived, stateful ses
 
 ## Key Features
 
-- **Card-as-tab terminals** — each card in the sidebar is a vertical tab; clicking it switches which terminal is visible in the main pane. PTY sessions are preserved across switches — the shell keeps running and scrollback is intact even when a tab is not visible.
+- **Card-as-tab workspace** — each card in the sidebar is a vertical tab. Cards have a type: `terminal` cards open a PTY session (shell keeps running and scrollback is intact even when a tab is not visible); `dungeon` cards are reserved for future AI Dungeon game state and currently render a placeholder. Clicking a tab switches which card is visible in the main pane.
 - **Keyboard tab navigation** — global shortcuts work whether focus is in the terminal or the sidebar. `Cmd+ArrowLeft` / `Cmd+ArrowRight` (macOS) or `Ctrl+ArrowLeft` / `Ctrl+ArrowRight` (Windows/Linux) cycle tabs with wrap-around. `Cmd/Ctrl+1` through `Cmd/Ctrl+9` jump directly to a tab by position. All eleven shortcuts suppress the WebView's default back/forward navigation unconditionally. Holding the modifier key (`Cmd` on macOS, `Ctrl` on Windows/Linux) for ≥ 250 ms reveals shortcut labels (`⌘1`–`⌘9` or `Ctrl+1`–`Ctrl+9`) on the first nine session cards as a discoverability hint; a quick tap that activates a shortcut produces no label flash.
 - **Multiple AI CLIs in one place** — designed to host tools like Claude Code, OpenCode, and other terminal-based AI assistants.
 - **Native desktop app** — built on Tauri v2 for a fast, lightweight shell around a modern web UI.
@@ -23,8 +23,8 @@ AI coding assistants increasingly run as CLIs that hold long-lived, stateful ses
 The app uses a three-part Mantine `AppShell`:
 
 - **Header** — app title, navbar toggle, and a gear button (⚙) that opens the Settings modal.
-- **Navbar (left sidebar)** — a "Cards" section with a `+` button to add cards. Each card is a `Tabs.Tab` whose label is rendered by the `SessionCard` component: a 3-row block showing the session slug, `repo:branch • path-tail`, and PR / Issue badges. Clicking the tab activates the corresponding terminal; the `×` button in the top-right of each card removes it and kills its PTY session.
-- **Main pane** — one `Tabs.Panel` per card, each containing an xterm.js terminal connected to a real shell via Tauri IPC. Inactive panels are hidden with CSS (`display: none`) but remain mounted, keeping their PTY sessions alive.
+- **Navbar (left sidebar)** — a "Cards" section with a `+` menu button. Clicking the button opens a dropdown with two options: **Terminal** (spawns a PTY session) and **Dungeon** (placeholder for future AI Dungeon content). Each card is a `Tabs.Tab` whose label is rendered by the `SessionCard` component: a 3-row block showing the session slug, `repo:branch • path-tail`, and PR / Issue badges. Clicking the tab activates the corresponding card; the `×` button in the top-right of each card removes it. Removing a terminal card kills its PTY session; removing a dungeon card has no PTY side effect.
+- **Main pane** — one `Tabs.Panel` per card. Terminal cards contain an xterm.js terminal connected to a real shell via Tauri IPC; inactive panels are hidden with CSS (`display: none`) but remain mounted, keeping PTY sessions alive. Dungeon cards display a "Dungeon: under construction" placeholder and do not spawn a PTY.
 
 When there are no cards, the main pane shows an empty-state prompt and the sidebar shows "No cards yet".
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -17,7 +17,7 @@ ai-dungeon/
 │   │   └── fonts.css # @font-face declarations for MesloLGS NF (all four faces)
 │   ├── App.tsx       # Root component — useReducer for cards + activeId; owns tab state
 │   ├── types/
-│   │   ├── card.ts               # Card type ({ id: string }) + isDungeonCard() predicate
+│   │   ├── card.ts               # Card interface ({ id: string; type: CardType }) and CardType = "terminal" | "dungeon"; type is set at creation and never mutated
 │   │   ├── session.ts            # SessionContext (OSC 6800) and ShellContext (OSC 7/7337) interfaces; all values are UNTRUSTED. branch and repo are optional on both types (cleared by empty OSC 7337).
 │   │   ├── sessionPayload.ts     # parseSessionContextPayload() / parseOsc7Payload() / parseOsc7337Payload() — validate all inbound OSC payloads before they enter app state. Single audit entry point for OSC 6800, OSC 7, and OSC 7337.
 │   │   └── sessionPayload.test.ts
@@ -28,9 +28,8 @@ ai-dungeon/
 │       │   ├── index.ts              # Barrel export
 │       │   └── Terminal.test.tsx
 │       └── layout/
-│           ├── AppLayout.tsx          # Mantine Tabs + AppShell — renders one CardPanel per card; threads sessionContext + shellContext callbacks to NavBar
-│           ├── CardPanel.tsx          # Per-card panel component: hosts useDungeonSidecar and renders the Terminal inside a Tabs.Panel
-│           ├── NavBar.tsx             # Sidebar — passes per-card sessionContext and shellContext to each SessionCard
+│           ├── AppLayout.tsx          # Mantine Tabs + AppShell — branches cards.map on card.type: terminal cards render <Terminal>, dungeon cards render a placeholder; includes assertNever exhaustiveness guard; threads sessionContext + shellContext callbacks to NavBar and Terminal
+│           ├── NavBar.tsx             # Sidebar — "+" opens a Mantine Menu with Terminal / Dungeon items; passes per-card sessionContext and shellContext to each SessionCard
 │           ├── SessionCard.tsx        # 3-row tab label: slug + close button, repo:branch • path-tail, PR/Issue badges; rendering precedence: sessionContext ?? shellContext ?? mock
 │           ├── SessionCard.test.tsx   # Unit tests for SessionCard (two-slot rendering + legacy cases)
 │           ├── sessionContext.mock.ts  # Deterministic mock SessionContext fixtures keyed by card id

--- a/e2e/terminal-font-rendering.spec.ts
+++ b/e2e/terminal-font-rendering.spec.ts
@@ -32,8 +32,8 @@ test.describe("MesloLGS NF font loading", () => {
     await page.goto("/");
 
     // Add a card so a <Terminal> component mounts and triggers font loading.
-    const addButton = page.getByRole("button", { name: /add/i });
-    await addButton.click();
+    await page.getByRole("button", { name: "Add card menu" }).click();
+    await page.getByRole("menuitem", { name: "Terminal" }).click();
 
     // Wait for the terminal root to appear, confirming the component mounted.
     await page.waitForSelector('[data-testid="terminal-root"]');

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,6 +6,7 @@ import { App, appReducer } from "./App";
 import type { AppState } from "./App";
 import type { SessionContext, ShellContext } from "./types/session";
 import { invoke } from "@tauri-apps/api/core";
+import { Terminal } from "./components/Terminal/Terminal";
 
 // Capture the latest callbacks passed to the Terminal mock so
 // integration tests can fire OSC context changes through the full plumbing.
@@ -105,7 +106,8 @@ describe("App", () => {
     expect(screen.queryByTestId("terminal-root")).toBeNull();
 
     // Add a card — terminal should appear.
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     expect(screen.getByTestId("terminal-root")).toBeInTheDocument();
     // Empty state disappears once a card exists.
@@ -116,7 +118,8 @@ describe("App", () => {
     const user = userEvent.setup();
     renderWithProviders(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     const removeButton = screen.getByRole("button", { name: /Remove card/i });
     expect(removeButton).toBeInTheDocument();
@@ -136,8 +139,10 @@ describe("App", () => {
     renderWithProviders(<App />);
 
     // Add two cards.
-    await user.click(screen.getByRole("button", { name: "Add card" }));
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     // Both terminals are mounted because keepMounted=true.
     expect(screen.queryAllByTestId("terminal-root")).toHaveLength(2);
@@ -166,9 +171,12 @@ describe("App", () => {
     renderWithProviders(<App />);
 
     // Add three cards: A (active), B, C.
-    await user.click(screen.getByRole("button", { name: "Add card" }));
-    await user.click(screen.getByRole("button", { name: "Add card" }));
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     const tabs = screen.getAllByRole("tab");
     expect(tabs).toHaveLength(3);
@@ -208,9 +216,12 @@ describe("App", () => {
     renderWithProviders(<App />);
 
     // Add three cards A, B, C. A is active (first-add rule).
-    await user.click(screen.getByRole("button", { name: "Add card" }));
-    await user.click(screen.getByRole("button", { name: "Add card" }));
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     const tabs = screen.getAllByRole("tab");
 
@@ -234,8 +245,10 @@ describe("App", () => {
     renderWithProviders(<App />);
 
     // Add two cards.
-    await user.click(screen.getByRole("button", { name: "Add card" }));
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     // Both spawns happen synchronously relative to user events. Drain the
     // microtask queue to ensure any async IIFE cancelled-path activity (which
@@ -273,7 +286,8 @@ describe("App", () => {
     renderWithProviders(<App />);
 
     // Add a card so there is an active tab.
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     const tabs = screen.getAllByRole("tab");
     expect(tabs).toHaveLength(1);
@@ -295,7 +309,8 @@ describe("App", () => {
     const user = userEvent.setup();
     renderWithProviders(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     // Fire the onSessionContextChange callback captured from the Terminal mock.
     await act(async () => {
@@ -312,11 +327,32 @@ describe("App", () => {
     expect(screen.getByText("backend-service")).toBeInTheDocument();
   });
 
+  it("adding a dungeon card from the menu mounts the placeholder, not a Terminal, and does not invoke pty_spawn", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    const user = userEvent.setup();
+    renderWithProviders(<App />);
+
+    // Open the menu and pick "Dungeon".
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Dungeon" }));
+
+    // No terminal root rendered.
+    expect(screen.queryByTestId("terminal-root")).toBeNull();
+    // Dungeon placeholder is in the DOM.
+    expect(screen.getByText("Dungeon: under construction")).toBeInTheDocument();
+    // No pty_spawn invocation.
+    const spawnCalls = mockInvoke.mock.calls.filter((c: unknown[]) => c[0] === "pty_spawn");
+    expect(spawnCalls).toHaveLength(0);
+    // The mocked Terminal factory was never called.
+    expect(Terminal).not.toHaveBeenCalled();
+  });
+
   it("setShellContext populates state.shellContext[id] independently of state.sessionContext[id]", async () => {
     const user = userEvent.setup();
     renderWithProviders(<App />);
 
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
     // Fire onShellContextChange — should NOT affect sessionContext.
     await act(async () => {
@@ -335,7 +371,7 @@ describe("App", () => {
 
 describe("appReducer", () => {
   it("activate ignores null while cards exist", () => {
-    const card = { id: "test-uuid-1" };
+    const card = { id: "test-uuid-1", type: "terminal" as const };
     const state: AppState = {
       cards: [card],
       activeId: "test-uuid-1",
@@ -352,7 +388,7 @@ describe("appReducer", () => {
   });
 
   it("setSessionContext stores ctx keyed by card id", () => {
-    const card = { id: "card-1" };
+    const card = { id: "card-1", type: "terminal" as const };
     const state: AppState = {
       cards: [card],
       activeId: "card-1",
@@ -386,7 +422,12 @@ describe("appReducer", () => {
       repo: { owner: "acme", name: "widgets" },
     };
     const stateAfterFirst = appReducer(
-      { cards: [{ id: "card-1" }], activeId: null, sessionContext: {}, shellContext: {} },
+      {
+        cards: [{ id: "card-1", type: "terminal" as const }],
+        activeId: null,
+        sessionContext: {},
+        shellContext: {},
+      },
       { type: "setSessionContext", id: "card-1", ctx: firstCtx },
     );
     const stateAfterSecond = appReducer(stateAfterFirst, {
@@ -413,7 +454,7 @@ describe("appReducer", () => {
   });
 
   it("remove cleans up sessionContext for the removed card", () => {
-    const card = { id: "card-1" };
+    const card = { id: "card-1", type: "terminal" as const };
     const ctx = {
       sessionTs: "20260425-120000",
       slug: "test",
@@ -433,7 +474,7 @@ describe("appReducer", () => {
 
   it("setShellContext stores ShellContext keyed by card id", () => {
     const state: AppState = {
-      cards: [{ id: "card-1" }],
+      cards: [{ id: "card-1", type: "terminal" as const }],
       activeId: "card-1",
       sessionContext: {},
       shellContext: {},
@@ -450,11 +491,45 @@ describe("appReducer", () => {
     expect(result).toBe(state); // referential equality — no-op
   });
 
+  it("add with cardType='dungeon' produces one dungeon card as activeId", () => {
+    const state: AppState = { cards: [], activeId: null, sessionContext: {}, shellContext: {} };
+    const result = appReducer(state, { type: "add", cardType: "dungeon" });
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].type).toBe("dungeon");
+    expect(result.activeId).toBe(result.cards[0].id);
+  });
+
+  it("add terminal then dungeon produces two cards in insertion order with dungeon active", () => {
+    const s0: AppState = { cards: [], activeId: null, sessionContext: {}, shellContext: {} };
+    const s1 = appReducer(s0, { type: "add", cardType: "terminal" });
+    const s2 = appReducer(s1, { type: "add", cardType: "dungeon" });
+    expect(s2.cards).toHaveLength(2);
+    expect(s2.cards[0].type).toBe("terminal");
+    expect(s2.cards[1].type).toBe("dungeon");
+    expect(s2.activeId).toBe(s2.cards[1].id);
+  });
+
+  it("remove dungeon card is pure — does not invoke any Tauri command", () => {
+    const terminalCard = { id: "term-1", type: "terminal" as const };
+    const dungeonCard = { id: "dung-1", type: "dungeon" as const };
+    const state: AppState = {
+      cards: [terminalCard, dungeonCard],
+      activeId: "term-1",
+      sessionContext: {},
+      shellContext: {},
+    };
+    const result = appReducer(state, { type: "remove", id: "dung-1" });
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].id).toBe("term-1");
+    // Reducer is pure — no Tauri commands should be called.
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
   it("setShellContext overwrites prior ShellContext (full replacement)", () => {
     const firstCtx: ShellContext = { workingDirectory: "/old", branch: "old-branch" };
     const secondCtx: ShellContext = { workingDirectory: "/new", branch: "new-branch" };
     const state: AppState = {
-      cards: [{ id: "card-1" }],
+      cards: [{ id: "card-1", type: "terminal" as const }],
       activeId: "card-1",
       sessionContext: {},
       shellContext: { "card-1": firstCtx },
@@ -468,7 +543,7 @@ describe("appReducer", () => {
   it("remove deletes per-card entry from shellContext", () => {
     const ctx: ShellContext = { workingDirectory: "/home/user", branch: "main" };
     const state: AppState = {
-      cards: [{ id: "card-1" }],
+      cards: [{ id: "card-1", type: "terminal" as const }],
       activeId: "card-1",
       sessionContext: {},
       shellContext: { "card-1": ctx },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useReducer } from "react";
 import { AppLayout } from "./components/layout";
-import type { Card } from "./types/card";
+import type { Card, CardType } from "./types/card";
 import type { SessionContext, ShellContext } from "./types/session";
 
 // ── State shape ───────────────────────────────────────────────────────────────
@@ -15,7 +15,7 @@ export interface AppState {
 // ── Actions ───────────────────────────────────────────────────────────────────
 
 type AppAction =
-  | { type: "add" }
+  | { type: "add"; cardType: CardType }
   | { type: "remove"; id: string }
   | { type: "activate"; id: string | null }
   | { type: "setSessionContext"; id: string; ctx: SessionContext }
@@ -26,7 +26,7 @@ type AppAction =
 export function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case "add": {
-      const newCard: Card = { id: globalThis.crypto.randomUUID() };
+      const newCard: Card = { id: globalThis.crypto.randomUUID(), type: action.cardType };
       return {
         // The new card is appended to the end of the list.
         cards: [...state.cards, newCard],
@@ -107,8 +107,12 @@ const initialState: AppState = { cards: [], activeId: null, sessionContext: {}, 
 export function App() {
   const [state, dispatch] = useReducer(appReducer, initialState);
 
-  const addCard = useCallback(() => {
-    dispatch({ type: "add" });
+  const addTerminalCard = useCallback(() => {
+    dispatch({ type: "add", cardType: "terminal" });
+  }, []);
+
+  const addDungeonCard = useCallback(() => {
+    dispatch({ type: "add", cardType: "dungeon" });
   }, []);
 
   const removeCard = useCallback((id: string) => {
@@ -134,7 +138,8 @@ export function App() {
       cards={state.cards}
       activeId={state.activeId}
       onActiveIdChange={setActiveId}
-      onAddCard={addCard}
+      onAddTerminalCard={addTerminalCard}
+      onAddDungeonCard={addDungeonCard}
       onRemoveCard={removeCard}
       sessionContext={state.sessionContext}
       onSessionContextChange={setSessionContext}

--- a/src/components/Terminal/useDungeonSidecar.test.ts
+++ b/src/components/Terminal/useDungeonSidecar.test.ts
@@ -22,7 +22,7 @@ async function flushPromises(): Promise<void> {
     // 5 iterations covers the max promise-chain depth:
     // open(.then) + catch + close(.then) + catch = 4 hops; 5 gives one extra for safety.
     await Array.from({ length: 5 }).reduce(
-      (chain) => chain.then(() => Promise.resolve()),
+      (chain: Promise<void>) => chain.then(() => Promise.resolve()),
       Promise.resolve(),
     );
   });
@@ -41,7 +41,7 @@ describe("useDungeonSidecar", () => {
   });
 
   it("calls dungeon_open on mount and dungeon_close on unmount", async () => {
-    const card: Card = { id: "test-card-1" };
+    const card: Card = { id: "test-card-1", type: "dungeon" as const };
 
     const { unmount } = renderHook(() => useDungeonSidecar(card));
 
@@ -59,7 +59,7 @@ describe("useDungeonSidecar", () => {
   it("does not call invoke when isDungeonCard returns false", async () => {
     vi.spyOn(cardModule, "isDungeonCard").mockReturnValue(false);
 
-    const card: Card = { id: "non-dungeon-card" };
+    const card: Card = { id: "non-dungeon-card", type: "terminal" as const };
     const { unmount } = renderHook(() => useDungeonSidecar(card));
 
     await flushPromises();
@@ -75,7 +75,7 @@ describe("useDungeonSidecar", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mockInvoke.mockRejectedValue(new Error("IPC error"));
 
-    const card: Card = { id: "error-card" };
+    const card: Card = { id: "error-card", type: "dungeon" as const };
 
     renderHook(() => useDungeonSidecar(card));
 
@@ -88,7 +88,7 @@ describe("useDungeonSidecar", () => {
   });
 
   it("calls dungeon_open exactly once when re-rendered with the same card.id", async () => {
-    const card: Card = { id: "stable-id" };
+    const card: Card = { id: "stable-id", type: "dungeon" as const };
 
     const { rerender } = renderHook(() => useDungeonSidecar(card));
 

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -74,7 +74,7 @@ vi.mock("./useModifierHeld", async (importOriginal) => {
   return { ...original, isMacPlatform: () => true };
 });
 
-import React, { useState } from "react";
+import React from "react";
 import { act, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../test-utils/render";
@@ -83,7 +83,6 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { _clearSpawnChainForTesting } from "../Terminal/Terminal";
-import type { ShellContext } from "../../types/session";
 
 type AnyMock = ReturnType<typeof vi.fn>;
 
@@ -159,7 +158,8 @@ describe("AppLayout", () => {
     const { container } = renderWithProviders(
       <AppLayout
         cards={[]}
-        onAddCard={vi.fn()}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         activeId={null}
         onActiveIdChange={vi.fn()}
@@ -189,8 +189,13 @@ describe("AppLayout", () => {
       renderWithProviders(
         <React.StrictMode>
           <AppLayout
-            cards={[{ id: "A" }, { id: "B" }, { id: "C" }]}
-            onAddCard={vi.fn()}
+            cards={[
+              { id: "A", type: "terminal" },
+              { id: "B", type: "terminal" },
+              { id: "C", type: "terminal" },
+            ]}
+            onAddTerminalCard={vi.fn()}
+            onAddDungeonCard={vi.fn()}
             onRemoveCard={vi.fn()}
             activeId="A"
             onActiveIdChange={vi.fn()}
@@ -228,12 +233,12 @@ describe("AppLayout", () => {
       expect(String(arg)).not.toContain("[pty write failed");
     }
 
-    // F-6: assert dungeon_open was called at least once per rendered card,
-    // proving the hook is actually wired from CardPanel.
+    // F-6 (updated): this branch uses inline type-branched rendering without CardPanel.
+    // Terminal cards do not trigger dungeon_open; assert none were called for the 3 terminal cards above.
     const dungeonOpenCalls = (mockInvoke.mock.calls as [string, unknown][]).filter(
       (c) => c[0] === "dungeon_open",
     );
-    expect(dungeonOpenCalls.length).toBeGreaterThanOrEqual(3);
+    expect(dungeonOpenCalls.length).toBe(0);
   });
 
   it("rapid card-add does not produce duplicate-spawn errors at the backend boundary", async () => {
@@ -243,8 +248,9 @@ describe("AppLayout", () => {
     // Render with one card first.
     const { rerender } = renderWithProviders(
       <AppLayout
-        cards={[{ id: "card-1" }]}
-        onAddCard={vi.fn()}
+        cards={[{ id: "card-1", type: "terminal" }]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         activeId="card-1"
         onActiveIdChange={vi.fn()}
@@ -263,8 +269,14 @@ describe("AppLayout", () => {
     await act(async () => {
       rerender(
         <AppLayout
-          cards={[{ id: "card-1" }, { id: "card-2" }, { id: "card-3" }, { id: "card-4" }]}
-          onAddCard={vi.fn()}
+          cards={[
+            { id: "card-1", type: "terminal" },
+            { id: "card-2", type: "terminal" },
+            { id: "card-3", type: "terminal" },
+            { id: "card-4", type: "terminal" },
+          ]}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
           onRemoveCard={vi.fn()}
           activeId="card-1"
           onActiveIdChange={vi.fn()}
@@ -312,15 +324,23 @@ describe("AppLayout", () => {
 // ── Keyboard navigation integration tests ─────────────────────────────────────
 
 describe("AppLayout — keyboard navigation", () => {
-  const threeCards = [{ id: "A" }, { id: "B" }, { id: "C" }];
+  const threeCards = [
+    { id: "A", type: "terminal" as const },
+    { id: "B", type: "terminal" as const },
+    { id: "C", type: "terminal" as const },
+  ];
 
-  function renderLayout(cards: { id: string }[], activeId: string | null) {
+  function renderLayout(
+    cards: { id: string; type: "terminal" | "dungeon" }[],
+    activeId: string | null,
+  ) {
     const onActiveIdChange = vi.fn();
     const user = userEvent.setup();
     const result = renderWithProviders(
       <AppLayout
         cards={cards}
-        onAddCard={vi.fn()}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         activeId={activeId}
         onActiveIdChange={onActiveIdChange}
@@ -405,7 +425,7 @@ describe("AppLayout — keyboard navigation", () => {
   });
 
   it("cycle is a no-op with one card", async () => {
-    const { onActiveIdChange, user } = renderLayout([{ id: "A" }], "A");
+    const { onActiveIdChange, user } = renderLayout([{ id: "A", type: "terminal" }], "A");
     await act(async () => {
       await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
     });
@@ -485,8 +505,13 @@ describe("AppLayout — shortcut tooltip overlay", () => {
 
     renderWithProviders(
       <AppLayout
-        cards={[{ id: "A" }, { id: "B" }, { id: "C" }]}
-        onAddCard={vi.fn()}
+        cards={[
+          { id: "A", type: "terminal" },
+          { id: "B", type: "terminal" },
+          { id: "C", type: "terminal" },
+        ]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         activeId="A"
         onActiveIdChange={vi.fn()}
@@ -534,7 +559,8 @@ describe("AppLayout — settings gear button and modal", () => {
     return renderWithProviders(
       <AppLayout
         cards={[]}
-        onAddCard={vi.fn()}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         activeId={null}
         onActiveIdChange={vi.fn()}
@@ -588,40 +614,9 @@ describe("AppLayout — settings gear button and modal", () => {
   });
 });
 
-// ── OSC 7 → OSC 7337 E2E integration (Step 4) ────────────────────────────────
-//
-// Renders the App→AppLayout→NavBar→SessionCard chain. Fires OSC 7 then
-// OSC 7337 for a card via the mocked xterm OSC handler API and asserts that
-// the branch name ("main") is rendered in the SessionCard.
-//
-// Step 0 diagnostic finding: the microtask race (suspect c) was NOT reproduced.
-// FIFO microtask ordering holds — OSC 7 always sets lastShellContextRef before
-// OSC 7337 reads it. Step 4 (pendingOsc7337Ref replay) is therefore deferred.
-// Issue: "Investigate: branch not shown on session card in normal repo
-// (cause unidentified)" — see GitHub issue created alongside this PR.
+// ── Dungeon card rendering tests ───────────────────────────────────────────────
 
-describe("AppLayout — OSC 7 → OSC 7337 E2E integration", () => {
-  // Wrapper that wires onShellContextChange back into AppLayout as controlled
-  // state so the SessionCard receives updated shellContext on handler fires.
-  function AppLayoutWithShellContext({ cardId }: { cardId: string }) {
-    const [shellContext, setShellContext] = useState<Record<string, ShellContext>>({});
-    return (
-      <AppLayout
-        cards={[{ id: cardId }]}
-        onAddCard={vi.fn()}
-        onRemoveCard={vi.fn()}
-        activeId={cardId}
-        onActiveIdChange={vi.fn()}
-        sessionContext={{}}
-        onSessionContextChange={vi.fn()}
-        shellContext={shellContext}
-        onShellContextChange={(_id, ctx) => {
-          setShellContext((prev) => ({ ...prev, [_id]: ctx }));
-        }}
-      />
-    );
-  }
-
+describe("AppLayout — dungeon card rendering", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _clearSpawnChainForTesting();
@@ -631,48 +626,148 @@ describe("AppLayout — OSC 7 → OSC 7337 E2E integration", () => {
     }) as unknown as typeof ResizeObserver;
   });
 
-  it("OSC 7 then OSC 7337 triggers SessionCard to display the branch name", async () => {
-    const cardId = "e2e-card-001";
+  it("renders the dungeon placeholder for a dungeon card and does not call pty_spawn", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    installSessionAwareMock(mockInvoke);
 
     await act(async () => {
-      renderWithProviders(<AppLayoutWithShellContext cardId={cardId} />);
+      renderWithProviders(
+        <AppLayout
+          cards={[{ id: "D", type: "dungeon" }]}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
+          onRemoveCard={vi.fn()}
+          activeId="D"
+          onActiveIdChange={vi.fn()}
+          sessionContext={{}}
+          onSessionContextChange={vi.fn()}
+          shellContext={{}}
+          onShellContextChange={vi.fn()}
+        />,
+      );
     });
 
-    // Wait for the OSC handlers to be registered (inside the font-load IIFE).
-    const MockXTerm = XTerm as unknown as AnyMock;
-    let registerOscHandlerSpy!: AnyMock;
-    await vi.waitFor(() => {
-      const lastInstance = MockXTerm.mock.results[MockXTerm.mock.results.length - 1]?.value;
-      expect(lastInstance?.parser?.registerOscHandler).toBeDefined();
-      registerOscHandlerSpy = lastInstance.parser.registerOscHandler as AnyMock;
-      expect(registerOscHandlerSpy).toHaveBeenCalledWith(7, expect.any(Function));
-      expect(registerOscHandlerSpy).toHaveBeenCalledWith(7337, expect.any(Function));
-    });
-
-    const osc7Handler = registerOscHandlerSpy.mock.calls.find((c: unknown[]) => c[0] === 7)![1] as (
-      data: string,
-    ) => boolean;
-    const osc7337Handler = registerOscHandlerSpy.mock.calls.find(
-      (c: unknown[]) => c[0] === 7337,
-    )![1] as (data: string) => boolean;
-
-    // Fire OSC 7 first (establishes workingDirectory in lastShellContextRef).
     await act(async () => {
-      osc7Handler("file:///home/user/my-project");
-      // Drain the microtask queue so the OSC 7 queueMicrotask callback fires.
-      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      await Promise.resolve();
     });
 
-    // Fire OSC 7337 (bare-name: repo<TAB>branch).
+    expect(screen.getByTestId("dungeon-placeholder-D")).toBeInTheDocument();
+    expect(screen.getByTestId("dungeon-placeholder-D").textContent).toBe(
+      "Dungeon: under construction",
+    );
+    const spawnCalls = mockInvoke.mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] === "pty_spawn" && (c[1] as Record<string, unknown>)?.sessionId === "D",
+    );
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("renders mixed terminal and dungeon cards: terminal triggers pty_spawn, dungeon does not", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    installSessionAwareMock(mockInvoke);
+
     await act(async () => {
-      osc7337Handler("my-project\tmain");
-      // Drain the microtask queue so the OSC 7337 queueMicrotask callback fires.
-      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      renderWithProviders(
+        <AppLayout
+          cards={[
+            { id: "T", type: "terminal" },
+            { id: "D", type: "dungeon" },
+          ]}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
+          onRemoveCard={vi.fn()}
+          activeId="T"
+          onActiveIdChange={vi.fn()}
+          sessionContext={{}}
+          onSessionContextChange={vi.fn()}
+          shellContext={{}}
+          onShellContextChange={vi.fn()}
+        />,
+      );
     });
 
-    // SessionCard must now display the branch name.
-    await vi.waitFor(() => {
-      expect(screen.getByText("main")).toBeInTheDocument();
+    await act(async () => {
+      await Promise.resolve();
     });
+
+    const terminalSpawnCalls = mockInvoke.mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] === "pty_spawn" && (c[1] as Record<string, unknown>)?.sessionId === "T",
+    );
+    expect(terminalSpawnCalls).toHaveLength(1);
+
+    const dungeonSpawnCalls = mockInvoke.mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] === "pty_spawn" && (c[1] as Record<string, unknown>)?.sessionId === "D",
+    );
+    expect(dungeonSpawnCalls).toHaveLength(0);
+
+    expect(screen.getByTestId("dungeon-placeholder-D")).toBeInTheDocument();
+  });
+
+  it("a dungeon card can be the active tab and keyboard navigation cycles to/from it", async () => {
+    const onActiveIdChange = vi.fn();
+    const user = userEvent.setup();
+
+    await act(async () => {
+      renderWithProviders(
+        <AppLayout
+          cards={[
+            { id: "T", type: "terminal" },
+            { id: "D", type: "dungeon" },
+          ]}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
+          onRemoveCard={vi.fn()}
+          activeId="T"
+          onActiveIdChange={onActiveIdChange}
+          sessionContext={{}}
+          onSessionContextChange={vi.fn()}
+          shellContext={{}}
+          onShellContextChange={vi.fn()}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await user.keyboard("{Meta>}{ArrowRight}{/Meta}");
+    });
+
+    expect(onActiveIdChange).toHaveBeenCalledWith("D");
+  });
+
+  it("removing a dungeon card does not invoke any pty_* command", async () => {
+    const mockInvoke = invoke as unknown as AnyMock;
+    installSessionAwareMock(mockInvoke);
+    const onRemoveCard = vi.fn();
+
+    await act(async () => {
+      renderWithProviders(
+        <AppLayout
+          cards={[{ id: "D", type: "dungeon" }]}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
+          onRemoveCard={onRemoveCard}
+          activeId="D"
+          onActiveIdChange={vi.fn()}
+          sessionContext={{}}
+          onSessionContextChange={vi.fn()}
+          shellContext={{}}
+          onShellContextChange={vi.fn()}
+        />,
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Clear any setup calls, then assert no pty_* calls from render/removal.
+    mockInvoke.mockClear();
+
+    const ptyAnyCalls = mockInvoke.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).startsWith("pty_"),
+    );
+    expect(ptyAnyCalls).toHaveLength(0);
   });
 });

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ActionIcon, AppShell, Burger, Group, Tabs, Text, Title } from "@mantine/core";
 import { useDisclosure, useHotkeys } from "@mantine/hooks";
 import { IconSettings } from "@tabler/icons-react";
@@ -6,15 +7,21 @@ import { useModifierHeld } from "./useModifierHeld";
 import type { Card } from "../../types/card";
 import type { SessionContext, ShellContext } from "../../types/session";
 import { NavBar } from "./NavBar";
-import { CardPanel } from "./CardPanel";
+import { Terminal } from "../Terminal";
 import { SettingsModal } from "../settings";
+
+function assertNever(x: never): React.ReactNode {
+  console.error(`Unexpected card type: ${String(x)}`);
+  return <Text c="red">Unknown card type: {String(x)}</Text>;
+}
 
 // Only consumer is App.tsx. `children` has been removed — AppLayout renders
 // Tabs.Panel content (Terminal instances) directly so that Tabs.List (navbar)
 // and Tabs.Panel (main) share the same Tabs context.
 interface AppLayoutProps {
   cards: Card[];
-  onAddCard: () => void;
+  onAddTerminalCard: () => void;
+  onAddDungeonCard: () => void;
   onRemoveCard: (id: string) => void;
   activeId: string | null;
   onActiveIdChange: (value: string | null) => void;
@@ -26,7 +33,8 @@ interface AppLayoutProps {
 
 export function AppLayout({
   cards,
-  onAddCard,
+  onAddTerminalCard,
+  onAddDungeonCard,
   onRemoveCard,
   activeId,
   onActiveIdChange,
@@ -147,7 +155,8 @@ export function AppLayout({
         <AppShell.Navbar p="md">
           <NavBar
             cards={cards}
-            onAddCard={onAddCard}
+            onAddTerminalCard={onAddTerminalCard}
+            onAddDungeonCard={onAddDungeonCard}
             onRemoveCard={onRemoveCard}
             sessionContext={sessionContext}
             shellContext={shellContext}
@@ -159,16 +168,29 @@ export function AppLayout({
           {cards.length === 0 ? (
             // Empty state: no cards, no terminals.
             <Text data-testid="main-empty-state" c="dimmed">
-              No card selected. Click + in the sidebar to add one.
+              No card selected. Click + in the sidebar to add a terminal or dungeon card.
             </Text>
           ) : (
             cards.map((card) => (
-              <CardPanel
-                key={card.id}
-                card={card}
-                onSessionContextChange={(ctx) => onSessionContextChange(card.id, ctx)}
-                onShellContextChange={(ctx) => onShellContextChange(card.id, ctx)}
-              />
+              // flex: 1, minHeight: 0 rather than height: 100% because AppShell.Main
+              // is already a flex column — flex children need flex: 1 to fill the
+              // available space, whereas height: 100% does not resolve reliably
+              // against a flex-column parent without an explicit definite height.
+              <Tabs.Panel key={card.id} value={card.id} style={{ flex: 1, minHeight: 0 }}>
+                {card.type === "terminal" ? (
+                  <Terminal
+                    sessionId={card.id}
+                    onSessionContextChange={(ctx) => onSessionContextChange(card.id, ctx)}
+                    onShellContextChange={(ctx) => onShellContextChange(card.id, ctx)}
+                  />
+                ) : card.type === "dungeon" ? (
+                  <Text data-testid={`dungeon-placeholder-${card.id}`} c="dimmed">
+                    Dungeon: under construction
+                  </Text>
+                ) : (
+                  assertNever(card.type)
+                )}
+              </Tabs.Panel>
             ))
           )}
         </AppShell.Main>

--- a/src/components/layout/NavBar.test.tsx
+++ b/src/components/layout/NavBar.test.tsx
@@ -25,7 +25,10 @@ function renderNavBar(ui: ReactElement) {
 }
 
 function makeCards(count: number) {
-  return Array.from({ length: count }, (_, i) => ({ id: `card-${String(i + 1)}` }));
+  return Array.from({ length: count }, (_, i) => ({
+    id: `card-${String(i + 1)}`,
+    type: "terminal" as const,
+  }));
 }
 
 describe("NavBar", () => {
@@ -33,7 +36,8 @@ describe("NavBar", () => {
     renderNavBar(
       <NavBar
         cards={[]}
-        onAddCard={vi.fn()}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         sessionContext={{}}
         shellContext={{}}
@@ -47,8 +51,12 @@ describe("NavBar", () => {
   it("renders provided cards with remove buttons", () => {
     renderNavBar(
       <NavBar
-        cards={[{ id: "abcdefgh-1234-5678-abcd-ef1234567890" }, { id: "12345678" }]}
-        onAddCard={vi.fn()}
+        cards={[
+          { id: "abcdefgh-1234-5678-abcd-ef1234567890", type: "terminal" },
+          { id: "12345678", type: "terminal" },
+        ]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         sessionContext={{}}
         shellContext={{}}
@@ -60,25 +68,71 @@ describe("NavBar", () => {
     expect(screen.getByRole("button", { name: "Remove card 12345678" })).toBeInTheDocument();
   });
 
-  it("calls onAddCard when the Add card button is clicked", async () => {
-    const onAddCard = vi.fn();
-    const onRemoveCard = vi.fn();
+  it("clicking the trigger then the Terminal item calls onAddTerminalCard", async () => {
+    const onAddTerminalCard = vi.fn();
+    const onAddDungeonCard = vi.fn();
     const user = userEvent.setup();
 
     renderNavBar(
       <NavBar
         cards={[]}
-        onAddCard={onAddCard}
-        onRemoveCard={onRemoveCard}
+        onAddTerminalCard={onAddTerminalCard}
+        onAddDungeonCard={onAddDungeonCard}
+        onRemoveCard={vi.fn()}
         sessionContext={{}}
         shellContext={{}}
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Add card" }));
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Terminal" }));
 
-    expect(onAddCard).toHaveBeenCalledTimes(1);
-    expect(onRemoveCard).not.toHaveBeenCalled();
+    expect(onAddTerminalCard).toHaveBeenCalledTimes(1);
+    expect(onAddDungeonCard).not.toHaveBeenCalled();
+  });
+
+  it("clicking the trigger then the Dungeon item calls onAddDungeonCard", async () => {
+    const onAddTerminalCard = vi.fn();
+    const onAddDungeonCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderNavBar(
+      <NavBar
+        cards={[]}
+        onAddTerminalCard={onAddTerminalCard}
+        onAddDungeonCard={onAddDungeonCard}
+        onRemoveCard={vi.fn()}
+        sessionContext={{}}
+        shellContext={{}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Dungeon" }));
+
+    expect(onAddDungeonCard).toHaveBeenCalledTimes(1);
+    expect(onAddTerminalCard).not.toHaveBeenCalled();
+  });
+
+  it("opening the menu and pressing ArrowDown then Enter activates the first item (Terminal)", async () => {
+    const onAddTerminalCard = vi.fn();
+    const user = userEvent.setup();
+
+    renderNavBar(
+      <NavBar
+        cards={[]}
+        onAddTerminalCard={onAddTerminalCard}
+        onAddDungeonCard={vi.fn()}
+        onRemoveCard={vi.fn()}
+        sessionContext={{}}
+        shellContext={{}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add card menu" }));
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onAddTerminalCard).toHaveBeenCalledTimes(1);
   });
 
   it("calls onRemoveCard with the correct id when a close button is clicked", async () => {
@@ -87,8 +141,12 @@ describe("NavBar", () => {
 
     renderNavBar(
       <NavBar
-        cards={[{ id: "a" }, { id: "b" }]}
-        onAddCard={vi.fn()}
+        cards={[
+          { id: "a", type: "terminal" },
+          { id: "b", type: "terminal" },
+        ]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={onRemoveCard}
         sessionContext={{}}
         shellContext={{}}
@@ -107,8 +165,9 @@ describe("NavBar", () => {
 
     renderNavBar(
       <NavBar
-        cards={[{ id: "a" }]}
-        onAddCard={vi.fn()}
+        cards={[{ id: "a", type: "terminal" }]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={onRemoveCard}
         sessionContext={{}}
         shellContext={{}}
@@ -129,8 +188,9 @@ describe("NavBar", () => {
 
     renderNavBar(
       <NavBar
-        cards={[{ id: "a" }]}
-        onAddCard={vi.fn()}
+        cards={[{ id: "a", type: "terminal" }]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={onRemoveCard}
         sessionContext={{}}
         shellContext={{}}
@@ -163,8 +223,9 @@ describe("NavBar", () => {
   it("applies width and overflow style declarations to Tabs.Tab so SessionCard does not overflow the navbar", () => {
     renderNavBar(
       <NavBar
-        cards={[{ id: "abcdefgh-1234-5678-abcd-ef1234567890" }]}
-        onAddCard={vi.fn()}
+        cards={[{ id: "abcdefgh-1234-5678-abcd-ef1234567890", type: "terminal" }]}
+        onAddTerminalCard={vi.fn()}
+        onAddDungeonCard={vi.fn()}
         onRemoveCard={vi.fn()}
         sessionContext={{}}
         shellContext={{}}
@@ -192,7 +253,8 @@ describe("NavBar", () => {
       renderNavBar(
         <NavBar
           cards={makeCards(3)}
-          onAddCard={vi.fn()}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
           onRemoveCard={vi.fn()}
           sessionContext={{}}
           shellContext={{}}
@@ -211,7 +273,8 @@ describe("NavBar", () => {
       renderNavBar(
         <NavBar
           cards={makeCards(3)}
-          onAddCard={vi.fn()}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
           onRemoveCard={vi.fn()}
           sessionContext={{}}
           shellContext={{}}
@@ -228,7 +291,8 @@ describe("NavBar", () => {
       renderNavBar(
         <NavBar
           cards={makeCards(11)}
-          onAddCard={vi.fn()}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
           onRemoveCard={vi.fn()}
           sessionContext={{}}
           shellContext={{}}
@@ -261,8 +325,9 @@ describe("NavBar", () => {
     renderWithProviders(
       <Tabs value={null} onChange={onChange} orientation="vertical">
         <NavBar
-          cards={[{ id: "a" }]}
-          onAddCard={vi.fn()}
+          cards={[{ id: "a", type: "terminal" }]}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
           onRemoveCard={onRemoveCard}
           sessionContext={{}}
           shellContext={{}}

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,11 +1,12 @@
-import { ActionIcon, Group, Tabs, Text, Title } from "@mantine/core";
+import { ActionIcon, Group, Menu, Tabs, Text, Title } from "@mantine/core";
 import type { Card } from "../../types/card";
 import type { SessionContext, ShellContext } from "../../types/session";
 import { SessionCard } from "./SessionCard";
 
 interface NavBarProps {
   cards: Card[];
-  onAddCard: () => void;
+  onAddTerminalCard: () => void;
+  onAddDungeonCard: () => void;
   onRemoveCard: (id: string) => void;
   sessionContext: Record<string, SessionContext>;
   shellContext: Record<string, ShellContext>;
@@ -15,7 +16,8 @@ interface NavBarProps {
 
 export function NavBar({
   cards,
-  onAddCard,
+  onAddTerminalCard,
+  onAddDungeonCard,
   onRemoveCard,
   sessionContext,
   shellContext,
@@ -25,9 +27,17 @@ export function NavBar({
     <>
       <Group justify="space-between">
         <Title order={5}>Cards</Title>
-        <ActionIcon aria-label="Add card" variant="default" onClick={onAddCard}>
-          +
-        </ActionIcon>
+        <Menu position="bottom-end" withinPortal>
+          <Menu.Target>
+            <ActionIcon aria-label="Add card menu" variant="default">
+              +
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item onClick={onAddTerminalCard}>Terminal</Menu.Item>
+            <Menu.Item onClick={onAddDungeonCard}>Dungeon</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
       </Group>
 
       {cards.length === 0 ? (

--- a/src/components/layout/tabNavigation.test.ts
+++ b/src/components/layout/tabNavigation.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
+import type { Card } from "../../types/card";
 import { getCycleTargetId, getNumericTargetId } from "./tabNavigation";
 
-const A = { id: "A" };
-const B = { id: "B" };
-const C = { id: "C" };
+const A: Card = { id: "A", type: "terminal" };
+const B: Card = { id: "B", type: "terminal" };
+const C: Card = { id: "C", type: "terminal" };
 
 describe("getCycleTargetId", () => {
   it("returns null for empty cards array", () => {
@@ -59,22 +60,28 @@ describe("getNumericTargetId", () => {
   });
 
   it("returns ninth card at position 9 with nine cards", () => {
-    const nineCards = [
-      { id: "1" },
-      { id: "2" },
-      { id: "3" },
-      { id: "4" },
-      { id: "5" },
-      { id: "6" },
-      { id: "7" },
-      { id: "8" },
-      { id: "9" },
+    const nineCards: Card[] = [
+      { id: "1", type: "terminal" },
+      { id: "2", type: "terminal" },
+      { id: "3", type: "terminal" },
+      { id: "4", type: "terminal" },
+      { id: "5", type: "terminal" },
+      { id: "6", type: "terminal" },
+      { id: "7", type: "terminal" },
+      { id: "8", type: "terminal" },
+      { id: "9", type: "terminal" },
     ];
     expect(getNumericTargetId(nineCards, 9)).toBe("9");
   });
 
   it("returns null at position 9 with only five cards", () => {
-    const fiveCards = [{ id: "1" }, { id: "2" }, { id: "3" }, { id: "4" }, { id: "5" }];
+    const fiveCards: Card[] = [
+      { id: "1", type: "terminal" },
+      { id: "2", type: "terminal" },
+      { id: "3", type: "terminal" },
+      { id: "4", type: "terminal" },
+      { id: "5", type: "terminal" },
+    ];
     expect(getNumericTargetId(fiveCards, 9)).toBeNull();
   });
 });

--- a/src/settings/integration.test.tsx
+++ b/src/settings/integration.test.tsx
@@ -100,7 +100,8 @@ function renderIntegration() {
       <MantineThemeBridge>
         <AppLayout
           cards={[]}
-          onAddCard={vi.fn()}
+          onAddTerminalCard={vi.fn()}
+          onAddDungeonCard={vi.fn()}
           onRemoveCard={vi.fn()}
           activeId={null}
           onActiveIdChange={vi.fn()}

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,13 +1,17 @@
-// Additional fields (e.g. title, kind) will be added when card content is introduced.
+// `type` is a literal-union discriminator field set at creation and never mutated.
+// Additional kind-specific fields will be added in a future change; if that happens,
+// this tagged interface should be converted to a proper discriminated union.
+export type CardType = "terminal" | "dungeon";
+
 export interface Card {
   id: string;
+  type: CardType;
 }
 
 /**
  * Predicate identifying dungeon cards (cards that participate in the Python sidecar lifecycle).
- * Today every card is a dungeon card. When Card.type lands, this becomes `card.type === "dungeon"` — a one-line edit.
  * Do NOT inline this predicate at call sites.
  */
-export function isDungeonCard(_card: Card): boolean {
-  return true;
+export function isDungeonCard(card: Card): boolean {
+  return card.type === "dungeon";
 }


### PR DESCRIPTION
Introduces a `type: "terminal" | "dungeon"` discriminator on `Card`. The NavBar `+` button is replaced with a Mantine Menu split control so users can pick the card kind explicitly.

Terminal cards behave identically to before — PTY spawned, OSC handlers registered, `keepMounted` semantics preserved. Dungeon cards render a "Dungeon: under construction" placeholder in the main panel and a minimal "Dungeon" entry in the sidebar without spawning a PTY or triggering any Tauri IPC.

The `AppLayout` render is guarded with an `assertNever` soft-fallback so future card kinds cannot silently fall through to the dungeon branch.