### PR TITLE
fix(settings): use empty string instead of dot for mkdir base path

### DIFF
--- a/src/settings/persistence.test.ts
+++ b/src/settings/persistence.test.ts
@@ -72,7 +72,7 @@ describe("saveSettings", () => {
     });
   });
 
-  it('calls mkdir with "." as the first arg before writeTextFile', async () => {
+  it('calls mkdir with "" (empty string) as the first arg before writeTextFile', async () => {
     const { saveSettings } = await import("./persistence");
     const { mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
     const mkdirMock = vi.mocked(mkdir);
@@ -82,7 +82,7 @@ describe("saveSettings", () => {
 
     expect(mkdirMock).toHaveBeenCalled();
     const mkdirFirstArg = mkdirMock.mock.calls[0][0];
-    expect(mkdirFirstArg).toBe(".");
+    expect(mkdirFirstArg).toBe("");
 
     // mkdir must be called before writeTextFile
     const mkdirOrder = mkdirMock.mock.invocationCallOrder[0];
@@ -90,7 +90,7 @@ describe("saveSettings", () => {
     expect(mkdirOrder).toBeLessThan(writeOrder);
   });
 
-  it('does NOT call mkdir with "" (empty string) — regression guard', async () => {
+  it('does NOT call mkdir with "." (trailing-dot regression guard)', async () => {
     const { saveSettings } = await import("./persistence");
     const { mkdir } = await import("@tauri-apps/plugin-fs");
     const mkdirMock = vi.mocked(mkdir);
@@ -99,7 +99,7 @@ describe("saveSettings", () => {
 
     const calls = mkdirMock.mock.calls;
     for (const call of calls) {
-      expect(call[0]).not.toBe("");
+      expect(call[0]).not.toBe(".");
     }
   });
 });

--- a/src/settings/persistence.ts
+++ b/src/settings/persistence.ts
@@ -54,12 +54,13 @@ export async function loadSettings(): Promise<Settings> {
  * Persist settings to disk. Creates the app-config directory if needed
  * (idempotent via recursive: true), then writes the full settings object as
  * two-space-indented JSON so the file is human-editable.
- *
- * Note: use "." (not "") as the mkdir path — empty string is undocumented
- * and may not work correctly across Tauri fs plugin versions.
  */
 export async function saveSettings(settings: Settings): Promise<void> {
-  await mkdir(".", { baseDir: BaseDirectory.AppConfig, recursive: true });
+  // Use "" (empty string) rather than "." as the path. "." resolves to
+  // "…com.alkofu.ai-dungeon/." — a trailing-dot component that doesn't match the
+  // `$APPCONFIG` whitelist in `fs:allow-mkdir`, so Tauri's scope checker rejects it.
+  // "" resolves to the base directory itself, satisfying the scope check.
+  await mkdir("", { baseDir: BaseDirectory.AppConfig, recursive: true });
   await writeTextFile("settings.json", JSON.stringify(settings, null, 2), {
     baseDir: BaseDirectory.AppConfig,
   });


### PR DESCRIPTION
Settings save fails with "No such file or directory" on first run because `mkdir(".", { baseDir: BaseDirectory.AppConfig, recursive: true })` produces a trailing-dot path that the Tauri scope checker rejects before the directory can be created.

The fix replaces `"."` with `""` as the path argument, which resolves to the AppConfig directory itself via the `baseDir` mechanism and avoids the path-normalisation issue entirely.

Test assertions in `persistence.test.ts` are updated to reflect the corrected argument, including a regression guard that documents the original symptom.

**Risk note:** Passing `""` with `baseDir` is not explicitly documented in tauri-plugin-fs@2.5.0 — manual macOS verification is required before merge. To verify: delete `~/Library/Application Support/com.alkofu.ai-dungeon/` and confirm that settings save succeeds on the next app launch.