### PR TITLE
chore(rust): add deny(unused) lint and Clippy CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,27 @@ jobs:
 
       - name: Run Playwright e2e tests
         run: pnpm exec playwright test
+
+  rust:
+    name: Rust lint and format
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Tauri system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+
+      - name: Format check
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check

--- a/TESTING.md
+++ b/TESTING.md
@@ -115,10 +115,10 @@ After `pnpm tauri dev` opens the app window, perform the following checks to con
 
 `.github/workflows/test.yml` defines three parallel jobs that run on every pull request and push to `main`:
 
-| Job     | What it runs                                                                                                                                                   |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `check` | `pnpm lint`, `pnpm format:check`, `pnpm test` — lint, format, and unit/component tests                                                                         |
-| `e2e`   | `pnpm exec playwright install --with-deps chromium` then `pnpm exec playwright test` — Playwright specs against the Vite dev server (no Tauri binary required) |
+| Job     | What it runs                                                                                                                                                                                             |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `check` | `pnpm lint`, `pnpm format:check`, `pnpm test` — lint, format, and unit/component tests                                                                                                                   |
+| `e2e`   | `pnpm exec playwright install --with-deps chromium` then `pnpm exec playwright test` — Playwright specs against the Vite dev server (no Tauri binary required)                                           |
 | `rust`  | `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` and `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — Clippy violations and formatting drift fail the build |
 
 The `e2e` job runs the Vite frontend only; the `playwright.config.ts` `webServer` block starts `pnpm dev` automatically, so no native system dependencies beyond Node.js and Chromium are needed on the runner.

--- a/TESTING.md
+++ b/TESTING.md
@@ -113,12 +113,13 @@ After `pnpm tauri dev` opens the app window, perform the following checks to con
 
 ## CI
 
-`.github/workflows/test.yml` defines two parallel jobs that run on every pull request and push to `main`:
+`.github/workflows/test.yml` defines three parallel jobs that run on every pull request and push to `main`:
 
 | Job     | What it runs                                                                                                                                                   |
 | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `check` | `pnpm lint`, `pnpm format:check`, `pnpm test` — lint, format, and unit/component tests                                                                         |
 | `e2e`   | `pnpm exec playwright install --with-deps chromium` then `pnpm exec playwright test` — Playwright specs against the Vite dev server (no Tauri binary required) |
+| `rust`  | `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` and `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — Clippy violations and formatting drift fail the build |
 
 The `e2e` job runs the Vite frontend only; the `playwright.config.ts` `webServer` block starts `pnpm dev` automatically, so no native system dependencies beyond Node.js and Chromium are needed on the runner.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,10 +43,10 @@ For the Rust backend (`src-tauri/`), the crates enforce `#![deny(unused)]`, so a
 
 > The commands below require the `clippy` and `rustfmt` rustup components. These are included in rustup's `default` profile. If you used a minimal profile, run: `rustup component add clippy rustfmt`
 
-| Command                                                           | Effect                                |
-| ----------------------------------------------------------------- | ------------------------------------- |
-| `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` | Run Clippy; warnings are errors |
-| `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`      | Check Rust formatting without writing |
-| `cargo fmt --manifest-path src-tauri/Cargo.toml`                  | Auto-format Rust source               |
+| Command                                                                          | Effect                                |
+| -------------------------------------------------------------------------------- | ------------------------------------- |
+| `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` | Run Clippy; warnings are errors       |
+| `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`                      | Check Rust formatting without writing |
+| `cargo fmt --manifest-path src-tauri/Cargo.toml`                                 | Auto-format Rust source               |
 
 These checks are also enforced by the `rust` CI job on every pull request.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,7 +30,7 @@ The Vite dev server runs on port 1420. The Rust backend is compiled on first run
 
 ### Code Quality
 
-The project uses [Oxlint](https://oxc.rs/docs/guide/usage/linter) for linting and [Oxfmt](https://oxc.rs/docs/guide/usage/formatter) for formatting.
+The project uses [Oxlint](https://oxc.rs/docs/guide/usage/linter) for linting and [Oxfmt](https://oxc.rs/docs/guide/usage/formatter) for formatting on the JavaScript/TypeScript side.
 
 | Command             | Effect                           |
 | ------------------- | -------------------------------- |
@@ -38,3 +38,15 @@ The project uses [Oxlint](https://oxc.rs/docs/guide/usage/linter) for linting an
 | `pnpm lint:fix`     | Lint and auto-fix violations     |
 | `pnpm format`       | Format all files in-place        |
 | `pnpm format:check` | Check formatting without writing |
+
+For the Rust backend (`src-tauri/`), the crates enforce `#![deny(unused)]`, so any unused variable, import, or dead code is a **compile error** — `cargo build` will fail, not just warn. Use the following commands to check Rust code quality locally before pushing:
+
+> The commands below require the `clippy` and `rustfmt` rustup components. These are included in rustup's `default` profile. If you used a minimal profile, run: `rustup component add clippy rustfmt`
+
+| Command                                                           | Effect                                |
+| ----------------------------------------------------------------- | ------------------------------------- |
+| `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` | Run Clippy; warnings are errors |
+| `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`      | Check Rust formatting without writing |
+| `cargo fmt --manifest-path src-tauri/Cargo.toml`                  | Auto-format Rust source               |
+
+These checks are also enforced by the `rust` CI job on every pull request.

--- a/src-tauri/src/dungeon.rs
+++ b/src-tauri/src/dungeon.rs
@@ -3,6 +3,7 @@ use std::sync::Mutex;
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
+#[derive(Default)]
 pub struct DungeonInner {
     /// Number of cards that have called dungeon_open without a matching dungeon_close.
     pub open_count: u32,
@@ -16,15 +17,6 @@ pub struct DungeonInner {
 #[derive(Default)]
 pub struct DungeonState {
     inner: Mutex<DungeonInner>,
-}
-
-impl Default for DungeonInner {
-    fn default() -> Self {
-        DungeonInner {
-            open_count: 0,
-            child: None,
-        }
-    }
 }
 
 // ── Path resolution ───────────────────────────────────────────────────────────
@@ -61,7 +53,7 @@ fn spawn_sidecar() -> Result<Child, String> {
 /// dungeon_close will skip the kill+wait step cleanly.
 pub(crate) fn dungeon_open_with_spawner<F>(
     inner: &mut DungeonInner,
-    spawner: F,
+    _spawner: F,
 ) -> Result<(), String>
 where
     F: FnOnce() -> Result<Child, String>,
@@ -71,7 +63,7 @@ where
     if inner.open_count == 1 {
         // First card: spawn the sidecar (debug builds only).
         #[cfg(debug_assertions)]
-        match spawner() {
+        match _spawner() {
             Ok(child) => {
                 inner.child = Some(child);
             }
@@ -213,11 +205,17 @@ mod tests {
 
         dungeon_close_inner(&mut inner).expect("close 1");
         assert_eq!(inner.open_count, 2, "count must be 2 after one close");
-        assert!(inner.child.is_some(), "child must still be alive at count=2");
+        assert!(
+            inner.child.is_some(),
+            "child must still be alive at count=2"
+        );
 
         dungeon_close_inner(&mut inner).expect("close 2");
         assert_eq!(inner.open_count, 1, "count must be 1 after two closes");
-        assert!(inner.child.is_some(), "child must still be alive at count=1");
+        assert!(
+            inner.child.is_some(),
+            "child must still be alive at count=1"
+        );
 
         dungeon_close_inner(&mut inner).expect("close 3");
         assert_eq!(inner.open_count, 0, "count must be 0 after three closes");
@@ -243,9 +241,18 @@ mod tests {
         let mut inner = DungeonInner::default();
 
         let result = dungeon_open_with_spawner(&mut inner, err_spawner);
-        assert!(result.is_ok(), "open must return Ok even when spawner fails");
-        assert_eq!(inner.open_count, 1, "count must be 1 even after spawn failure");
-        assert!(inner.child.is_none(), "child must be None after spawn failure");
+        assert!(
+            result.is_ok(),
+            "open must return Ok even when spawner fails"
+        );
+        assert_eq!(
+            inner.open_count, 1,
+            "count must be 1 even after spawn failure"
+        );
+        assert!(
+            inner.child.is_none(),
+            "child must be None after spawn failure"
+        );
 
         // close (1→0): must succeed without panic even with child=None
         let close_result = dungeon_close_inner(&mut inner);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused)]
 mod dungeon;
 mod pty;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![deny(unused)]
 
 fn main() {
     ai_dungeon_lib::run()

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -943,7 +943,9 @@ mod tests {
         // Cleared OSC 7337 must be present
         let cleared_needle: &[u8] = b"\x1b]7337;\x1b\\";
         assert!(
-            stdout.windows(cleared_needle.len()).any(|w| w == cleared_needle),
+            stdout
+                .windows(cleared_needle.len())
+                .any(|w| w == cleared_needle),
             "expected cleared OSC 7337 in stdout, got: {:?}",
             String::from_utf8_lossy(&stdout),
         );
@@ -956,7 +958,7 @@ mod tests {
                 if let Some(esc_idx) = after_open.iter().position(|&b| b == 0x1b) {
                     let payload = &after_open[..esc_idx];
                     assert!(
-                        !(!payload.is_empty() && payload.ends_with(b"\t")),
+                        payload.is_empty() || !payload.ends_with(b"\t"),
                         "tab-delimited OSC 7337 with empty branch must not appear, got: {:?}",
                         String::from_utf8_lossy(&stdout),
                     );
@@ -977,12 +979,13 @@ mod tests {
     #[serial]
     fn shell_init_polyglot_emits_osc7_only_once_when_cwd_is_unchanged() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let stdout = capture_polyglot_output(
-            tmp.path(),
-            "__ai_dungeon_emit_ctx; __ai_dungeon_emit_ctx",
-        );
+        let stdout =
+            capture_polyglot_output(tmp.path(), "__ai_dungeon_emit_ctx; __ai_dungeon_emit_ctx");
         let needle = b"\x1b]7;file://";
-        let count = stdout.windows(needle.len()).filter(|w| *w == needle).count();
+        let count = stdout
+            .windows(needle.len())
+            .filter(|w| *w == needle)
+            .count();
         assert_eq!(
             count, 1,
             "expected exactly 1 OSC 7 emission across two prompts in same CWD, got {count}; stdout: {:?}",
@@ -1006,7 +1009,10 @@ mod tests {
         );
         let stdout = capture_polyglot_output(tmp.path(), &cmd);
         let needle = b"\x1b]7;file://";
-        let count = stdout.windows(needle.len()).filter(|w| *w == needle).count();
+        let count = stdout
+            .windows(needle.len())
+            .filter(|w| *w == needle)
+            .count();
         assert_eq!(
             count, 2,
             "expected exactly 2 OSC 7 emissions across two prompts with cd between, got {count}; stdout: {:?}",
@@ -1014,8 +1020,14 @@ mod tests {
         );
         // Also verify OSC 7337 still fires on every prompt (cadence unchanged)
         let osc7337_needle = b"\x1b]7337;";
-        let osc7337_count = stdout.windows(osc7337_needle.len()).filter(|w| *w == osc7337_needle).count();
-        assert_eq!(osc7337_count, 2, "expected OSC 7337 on every prompt regardless of CWD");
+        let osc7337_count = stdout
+            .windows(osc7337_needle.len())
+            .filter(|w| *w == osc7337_needle)
+            .count();
+        assert_eq!(
+            osc7337_count, 2,
+            "expected OSC 7337 on every prompt regardless of CWD"
+        );
     }
 
     /// `try_reserve_session_id` must return `Ok(1)` on the first call, then


### PR DESCRIPTION
Rust warnings were silently slipping through builds because there were no Rust lint or format gates in CI. This adds `#![deny(unused)]` to both crates so unused code is a compile error locally, renames the cfg-gated `spawner` parameter to `_spawner` idiomatically, and adds a `rust` CI job running Clippy (`-D warnings`) and rustfmt against the Tauri crate.

Pre-existing Clippy violations in `pty.rs` (a `nonminimal_bool` simplification) and `dungeon.rs` (derivable `Default` impl) were also fixed as part of enabling `-D warnings` — these were surfaced by the new gate, not introduced by it.