### PR TITLE
feat(dx): add dev:worktree script for one-command worktree preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ pnpm tauri dev
 
 This installs dependencies and launches the app in development mode. You will need Rust, Node.js v18+, and pnpm installed first — see [docs/getting-started.md](docs/getting-started.md) for full prerequisites and setup instructions.
 
+To preview a specific git worktree without manually `cd`-ing into it, use `pnpm dev:worktree <worktree-name>` — see [Previewing a worktree](docs/getting-started.md#previewing-a-worktree) for details.
+
 ## Documentation
 
 - [Getting Started](docs/getting-started.md) — prerequisites, development workflow, and code quality tooling.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,3 +50,31 @@ For the Rust backend (`src-tauri/`), the crates enforce `#![deny(unused)]`, so a
 | `cargo fmt --manifest-path src-tauri/Cargo.toml`                                 | Auto-format Rust source               |
 
 These checks are also enforced by the `rust` CI job on every pull request.
+
+### Previewing a worktree
+
+Worktrees under `.worktrees/<name>/` can be previewed in isolation without manually `cd`-ing into them — a single command from the repo root handles the full workflow.
+
+```sh
+pnpm dev:worktree <worktree-name>
+```
+
+Equivalently, you can invoke the script directly:
+
+```sh
+bash scripts/dev-worktree.sh <worktree-name>
+```
+
+The script assumes worktrees live under `.worktrees/<name>/` — the project's standard git worktree location — so future contributors understand the convention is intentional.
+
+What the script does, in order:
+
+- Validates that the worktree directory exists under `.worktrees/`.
+- Checks that port 1420 is free (Tauri's Vite dev server always binds to port 1420; only one preview can run at a time — this is intentional and matches the upstream Vite/Tauri convention).
+- Runs `pnpm install --prefer-offline` inside the worktree.
+- `exec`s `pnpm tauri dev`, replacing the shell process so Ctrl-C tears down Tauri cleanly.
+
+**Common errors:**
+
+- `Error: worktree '<name>' not found at ...` — the worktree directory does not exist. Run `git worktree list` to see which worktrees are currently checked out.
+- `Error: port 1420 is already in use.` — another `pnpm tauri dev` instance (or some other process) is bound to the port. Run `lsof -i :1420` to identify it and stop it before starting a new preview.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -49,6 +49,8 @@ ai-dungeon/
 │   ├── icons/        # App icons (all sizes)
 │   ├── Cargo.toml
 │   └── tauri.conf.json
+├── scripts/
+│   └── dev-worktree.sh   # Worktree dev launcher — validates the named worktree under `.worktrees/`, checks port 1420, runs `pnpm install --prefer-offline`, then `exec`s `pnpm tauri dev`. Invoked via `pnpm dev:worktree <name>`.
 ├── index.html
 ├── vite.config.ts
 ├── tsconfig.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:worktree": "bash scripts/dev-worktree.sh",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the repo root relative to this script's own location so the script
+# works regardless of the caller's current working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Argument validation -------------------------------------------------------
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: bash scripts/dev-worktree.sh <worktree-name>" >&2
+  exit 2
+fi
+
+if [ "$#" -gt 1 ]; then
+  echo "Error: too many arguments; expected exactly one worktree name" >&2
+  echo "Usage: bash scripts/dev-worktree.sh <worktree-name>" >&2
+  exit 2
+fi
+
+WORKTREE_NAME="$1"
+
+# Worktrees live under .worktrees/<name>/ — the project's standard git worktree
+# location. Paths outside that directory are not supported.
+WORKTREE_DIR="$REPO_ROOT/.worktrees/$WORKTREE_NAME"
+
+# --- Directory existence check -------------------------------------------------
+
+if [ ! -d "$WORKTREE_DIR" ]; then
+  echo "Error: worktree '$WORKTREE_NAME' not found at $WORKTREE_DIR" >&2
+  echo "Hint: run \`git worktree list\` to see existing worktrees." >&2
+  exit 1
+fi
+
+# --- Port pre-check ------------------------------------------------------------
+# Run BEFORE pnpm install so a port conflict exits immediately rather than
+# wasting time on a doomed install run.
+
+if command -v lsof >/dev/null 2>&1; then
+  PORT_PIDS="$(lsof -nP -iTCP:1420 -sTCP:LISTEN -t || true)"
+  if [ -n "$PORT_PIDS" ]; then
+    echo "Error: port 1420 is already in use." >&2
+    echo "Another instance of \`pnpm tauri dev\` (or another process) is bound to it." >&2
+    echo "Run \`lsof -i :1420\` to see which process is using it." >&2
+    exit 1
+  fi
+else
+  echo "Warning: lsof not found, skipping port pre-check" >&2
+fi
+
+# --- Install and launch --------------------------------------------------------
+
+echo "→ Installing dependencies in $WORKTREE_DIR"
+cd "$WORKTREE_DIR"
+pnpm install --prefer-offline
+
+echo "→ Starting \`pnpm tauri dev\` in $WORKTREE_NAME"
+exec pnpm tauri dev


### PR DESCRIPTION
Previously, previewing a feature branch in its own worktree required manually running `pnpm install` and `pnpm tauri dev` from the right directory, with no guard against port conflicts or missing worktrees. This PR adds `scripts/dev-worktree.sh` — a launcher that validates the named worktree exists under `.worktrees/`, checks that port 1420 is free, installs dependencies with `--prefer-offline`, then `exec`s `pnpm tauri dev`. Developers can now type `pnpm dev:worktree <name>` from the repo root and get a working Tauri preview with one command.

The new command is documented in `docs/getting-started.md` and cross-referenced from `README.md`.