### PR TITLE
perf(ui): eliminate terminal blink during navbar drag

### DIFF
--- a/src/components/Terminal/Terminal.test.tsx
+++ b/src/components/Terminal/Terminal.test.tsx
@@ -438,6 +438,79 @@ describe("Terminal", () => {
     );
   });
 
+  // ── MutationObserver drag-end refit ──────────────────────────────────────
+
+  it("MutationObserver: calls fitAddon.fit() and pty_resize when 'is-resizing' class is removed and terminal is ready", async () => {
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
+
+    // Wait for both listen() calls to confirm isReadyRef.current = true.
+    const mockListen = listen as unknown as AnyMock;
+    await vi.waitFor(() => {
+      expect(mockListen).toHaveBeenCalledTimes(2);
+    });
+
+    const fitInstance = getFitInstance();
+    fitInstance.fit.mockClear();
+    (invoke as unknown as AnyMock).mockClear();
+
+    // Simulate drag start: add the sentinel class.
+    document.body.classList.add("is-resizing");
+    // Flush MutationObserver microtask — the observer fires asynchronously.
+    await Promise.resolve();
+
+    // Simulate drag end: remove the sentinel class.
+    document.body.classList.remove("is-resizing");
+    await Promise.resolve();
+
+    // fitAddon.fit() must have been called exactly once after removal.
+    expect(fitInstance.fit).toHaveBeenCalledTimes(1);
+
+    // pty_resize must have been called because the terminal is ready.
+    await vi.waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("pty_resize", {
+        sessionId: "00000000-0000-0000-0000-000000000001",
+        cols: 80,
+        rows: 24,
+      });
+    });
+  });
+
+  it("MutationObserver: calls fitAddon.fit() but NOT pty_resize when 'is-resizing' is removed and terminal is NOT ready", async () => {
+    // Make spawn hang so isReadyRef stays false.
+    const mockInvoke = invoke as unknown as AnyMock;
+    mockInvoke.mockImplementation(
+      (cmd: string) =>
+        new Promise((resolve) => {
+          if (cmd !== "pty_spawn") resolve(undefined);
+          // pty_spawn never resolves → isReadyRef stays false.
+        }),
+    );
+
+    renderWithProviders(<Terminal sessionId="00000000-0000-0000-0000-000000000001" />);
+
+    // Give React a tick to mount and set up the observers.
+    await new Promise((r) => setTimeout(r, 10));
+
+    const fitInstance = getFitInstance();
+    fitInstance.fit.mockClear();
+    mockInvoke.mockClear();
+
+    // Simulate drag start then end.
+    document.body.classList.add("is-resizing");
+    await Promise.resolve();
+    document.body.classList.remove("is-resizing");
+    await Promise.resolve();
+
+    // fitAddon.fit() must be called (always, regardless of ready state).
+    expect(fitInstance.fit).toHaveBeenCalledTimes(1);
+
+    // pty_resize must NOT have been called.
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "pty_resize",
+      expect.objectContaining({ sessionId: "00000000-0000-0000-0000-000000000001" }),
+    );
+  });
+
   it("disposes terminal and disconnects observer on unmount", async () => {
     const { unmount } = renderWithProviders(
       <Terminal sessionId="00000000-0000-0000-0000-000000000001" />,

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -294,7 +294,11 @@ export function Terminal({
 
     // ── ResizeObserver ────────────────────────────────────────────────────────
     // Always call fitAddon.fit() — the PTY resize IPC only fires once ready.
+    // Exception: skip during navbar drag (body class "is-resizing" is set by
+    // NavbarResizer on pointerDown and cleared on pointerUp/pointerCancel) to
+    // prevent fitAddon.fit() from redrawing the terminal at ~60fps during drag.
     const observer = new ResizeObserver(() => {
+      if (document.body.classList.contains("is-resizing")) return;
       fitAddon.fit();
       if (!isReadyRef.current) return;
 
@@ -309,6 +313,27 @@ export function Terminal({
       });
     });
     observer.observe(containerRef.current);
+
+    // ── MutationObserver (drag-end refit) ────────────────────────────────────
+    // After NavbarResizer removes "is-resizing" the ResizeObserver will not
+    // re-fire (the CSS variable was already set to the final value via direct
+    // DOM mutation in onWidthChange, so onCommit's React re-render causes no
+    // layout change). This MutationObserver triggers the one final fit() call.
+    let wasResizing = false;
+    const mutationObserver = new MutationObserver(() => {
+      const isResizing = document.body.classList.contains("is-resizing");
+      if (wasResizing && !isResizing) {
+        fitAddon.fit();
+        if (isReadyRef.current) {
+          const dims = fitAddon.proposeDimensions();
+          if (dims) {
+            void invoke("pty_resize", { sessionId, cols: dims.cols, rows: dims.rows });
+          }
+        }
+      }
+      wasResizing = isResizing;
+    });
+    mutationObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] });
 
     // ── Spawn-chain: append this mount's spawn to the per-sid chain ───────────
     // `previousChain` is whatever the prior mount (or a prior kill) settled as.
@@ -539,6 +564,7 @@ export function Terminal({
       // Clear accumulated shell context so a remount starts clean.
       lastShellContextRef.current = null;
       observer.disconnect();
+      mutationObserver.disconnect();
       oscDisposable?.dispose(); // OSC 6800
       osc7Handler?.dispose(); // OSC 7
       osc7337Handler?.dispose(); // OSC 7337

--- a/src/components/layout/AppLayout.test.tsx
+++ b/src/components/layout/AppLayout.test.tsx
@@ -1020,13 +1020,16 @@ describe("AppLayout — navbar resizer", () => {
     // Initial width from mockNavbarWidthHolder.current (250)
     expect(sep).toHaveAttribute("aria-valuenow", "250");
 
-    // Start a drag: pointerDown at x=250, then move to x=350 → liveWidth becomes 350
+    // Start a drag: pointerDown at x=250, then move to x=350 → visual width becomes 350.
+    // Note: liveWidth (React state) is NOT updated on pointermove in the new design —
+    // the parent mutates --app-shell-navbar-width directly to avoid re-renders.
+    // NavbarResizer mutates aria-valuenow directly via separatorRef so it stays accurate.
     act(() => {
       fireEvent.pointerDown(sep, { pointerId: 1, clientX: 250, buttons: 1 });
       fireEvent.pointerMove(sep, { pointerId: 1, clientX: 350, buttons: 1 });
     });
 
-    // liveWidth should now reflect the drag position (350)
+    // aria-valuenow reflects the drag position (350) via direct DOM mutation in NavbarResizer.
     expect(sep).toHaveAttribute("aria-valuenow", "350");
 
     // Simulate an external settings change arriving mid-drag

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState } from "react";
+import React, { Suspense, useEffect, useRef, useState } from "react";
 import {
   ActionIcon,
   AppShell,
@@ -82,6 +82,11 @@ export function AppLayout({
   // Track whether a drag is in progress so the effect below does not snap the
   // width back to the persisted value while the user is still dragging (F-6).
   const draggingRef = React.useRef(false);
+  // Ref to the AppShell root element for direct CSS variable mutation during drag.
+  // This avoids scheduling a React re-render on every pointermove, which would
+  // cause Mantine to update --app-shell-navbar-width via a style recalc and
+  // trigger the xterm ResizeObserver → terminal.fit() blink path.
+  const appShellRef = useRef<HTMLElement | null>(null);
   // Sync liveWidth when persistedWidth changes (e.g. settings reloaded from disk),
   // but only when no drag is in progress.
   useEffect(() => {
@@ -157,6 +162,7 @@ export function AppLayout({
       onChange={onActiveIdChange}
     >
       <AppShell
+        ref={appShellRef}
         header={{ height: 60 }}
         navbar={{
           width: liveWidth,
@@ -229,10 +235,19 @@ export function AppLayout({
             width={liveWidth}
             onWidthChange={(next) => {
               draggingRef.current = true;
-              setLiveWidth(next);
+              // Direct CSS variable mutation — no React re-render during drag.
+              // Mantine sets --app-shell-navbar-width via a <style> tag on :root;
+              // we override it with an inline style on the AppShell root element
+              // to drive the layout at full frame rate without scheduling a React
+              // render on every pointermove. Inline styles have higher specificity
+              // than stylesheet rules, so this override wins on the AppShell subtree.
+              appShellRef.current?.style.setProperty("--app-shell-navbar-width", `${next}px`);
             }}
             onCommit={(final) => {
               draggingRef.current = false;
+              // Sync React state once after drag ends so any subsequent re-render
+              // (e.g., tab switch, settings update) uses the committed width.
+              setLiveWidth(final);
               setWidth(final);
             }}
             min={MIN}

--- a/src/components/layout/NavbarResizer.test.tsx
+++ b/src/components/layout/NavbarResizer.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from "react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { NavbarResizer } from "./NavbarResizer";
 
@@ -67,6 +67,10 @@ describe("NavbarResizer — pointer drag", () => {
     // jsdom does not implement setPointerCapture — stub it on the prototype.
     window.HTMLElement.prototype.setPointerCapture = setPointerCaptureMock;
     window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.classList.remove("is-resizing");
   });
 
   it("drag from clientX 250 to 350 calls onWidthChange with 350 (delta +100)", () => {
@@ -135,6 +139,41 @@ describe("NavbarResizer — pointer drag", () => {
     fireEvent.pointerCancel(sep, { pointerId: 1 });
 
     expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds 'is-resizing' class to document.body on pointerDown", () => {
+    renderResizer({ width: 250 });
+    const sep = screen.getByRole("separator");
+    expect(document.body.classList.contains("is-resizing")).toBe(false);
+    fireEvent.pointerDown(sep, { pointerId: 1, clientX: 250, buttons: 1 });
+    expect(document.body.classList.contains("is-resizing")).toBe(true);
+  });
+
+  it("removes 'is-resizing' class from document.body on pointerUp", () => {
+    renderResizer({ width: 250 });
+    const sep = screen.getByRole("separator");
+    fireEvent.pointerDown(sep, { pointerId: 1, clientX: 250, buttons: 1 });
+    expect(document.body.classList.contains("is-resizing")).toBe(true);
+    fireEvent.pointerUp(sep, { pointerId: 1, clientX: 300 });
+    expect(document.body.classList.contains("is-resizing")).toBe(false);
+  });
+
+  it("removes 'is-resizing' class from document.body on pointerCancel", () => {
+    renderResizer({ width: 250 });
+    const sep = screen.getByRole("separator");
+    fireEvent.pointerDown(sep, { pointerId: 1, clientX: 250, buttons: 1 });
+    expect(document.body.classList.contains("is-resizing")).toBe(true);
+    fireEvent.pointerCancel(sep, { pointerId: 1 });
+    expect(document.body.classList.contains("is-resizing")).toBe(false);
+  });
+
+  it("removes 'is-resizing' class from document.body when component unmounts mid-drag", () => {
+    const { unmount } = renderResizer({ width: 250 });
+    const sep = screen.getByRole("separator");
+    fireEvent.pointerDown(sep, { pointerId: 1, clientX: 250, buttons: 1 });
+    expect(document.body.classList.contains("is-resizing")).toBe(true);
+    unmount();
+    expect(document.body.classList.contains("is-resizing")).toBe(false);
   });
 });
 

--- a/src/components/layout/NavbarResizer.test.tsx
+++ b/src/components/layout/NavbarResizer.test.tsx
@@ -180,6 +180,31 @@ describe("NavbarResizer — pointer drag", () => {
     unmount();
     expect(document.body.classList.contains("is-resizing")).toBe(false);
   });
+
+  it("defers 'is-resizing' removal to a RAF (class still present synchronously after pointerUp)", () => {
+    // Override the default synchronous RAF stub with one that captures
+    // the callback but does NOT invoke it — so we can assert the class
+    // is still present immediately after pointerUp.
+    const rafCallbacks: FrameRequestCallback[] = [];
+    window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length; // handle (unused)
+    };
+
+    renderResizer({ width: 250 });
+    const sep = screen.getByRole("separator");
+
+    fireEvent.pointerDown(sep, { pointerId: 1, clientX: 250, buttons: 1 });
+    fireEvent.pointerUp(sep, { pointerId: 1, clientX: 300 });
+
+    // Synchronously after pointerUp the class must still be set (RAF not yet run).
+    expect(document.body.classList.contains("is-resizing")).toBe(true);
+    expect(rafCallbacks).toHaveLength(1);
+
+    // Flushing the RAF removes the class.
+    rafCallbacks[0]!(0);
+    expect(document.body.classList.contains("is-resizing")).toBe(false);
+  });
 });
 
 describe("NavbarResizer — keyboard", () => {

--- a/src/components/layout/NavbarResizer.test.tsx
+++ b/src/components/layout/NavbarResizer.test.tsx
@@ -67,6 +67,11 @@ describe("NavbarResizer — pointer drag", () => {
     // jsdom does not implement setPointerCapture — stub it on the prototype.
     window.HTMLElement.prototype.setPointerCapture = setPointerCaptureMock;
     window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+    // Make RAF synchronous so body-class removal assertions work without async flushing.
+    window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    };
   });
 
   afterEach(() => {

--- a/src/components/layout/NavbarResizer.tsx
+++ b/src/components/layout/NavbarResizer.tsx
@@ -24,7 +24,7 @@
  *   against.
  */
 
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 
 export interface NavbarResizerProps {
   /** Current sidebar width in pixels (used for ARIA and drag start). */
@@ -56,8 +56,22 @@ export function NavbarResizer({
   const startClientXRef = useRef(0);
   const startWidthRef = useRef(0);
   // Track the most recent live width so onCommit fires the right value on pointerUp.
+  // Sync from the `width` prop only when not dragging — syncing unconditionally
+  // would overwrite the drag-accumulated value when the parent re-renders mid-drag
+  // (e.g., an external settings update arrives while the user is still dragging).
   const currentWidthRef = useRef(width);
-  currentWidthRef.current = width;
+
+  useEffect(() => {
+    if (!draggingRef.current) {
+      currentWidthRef.current = width;
+    }
+  }, [width]);
+  // Ref to the separator element for direct aria-valuenow mutation during drag.
+  // Because the parent no longer updates liveWidth on every pointermove (to avoid
+  // React re-renders that cause the terminal blink), aria-valuenow would otherwise
+  // stay stale at the pre-drag value throughout the drag. We mutate it directly
+  // so screen readers and tests see the live position without scheduling a re-render.
+  const separatorRef = useRef<HTMLDivElement | null>(null);
 
   function handlePointerDown(e: React.PointerEvent<HTMLDivElement>) {
     e.currentTarget.setPointerCapture(e.pointerId);
@@ -70,6 +84,9 @@ export function NavbarResizer({
     if (!draggingRef.current) return;
     const next = clamp(startWidthRef.current + (e.clientX - startClientXRef.current), min, max);
     currentWidthRef.current = next;
+    // Update aria-valuenow directly so it reflects the live drag position.
+    // The React prop (width) stays at the pre-drag value until onCommit fires.
+    separatorRef.current?.setAttribute("aria-valuenow", String(next));
     onWidthChange(next);
   }
 
@@ -78,6 +95,8 @@ export function NavbarResizer({
     draggingRef.current = false;
     e.currentTarget.releasePointerCapture(e.pointerId);
     onCommit(currentWidthRef.current);
+    // aria-valuenow will be set correctly by React on the next render after
+    // onCommit triggers setLiveWidth(final) in the parent.
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
@@ -96,6 +115,7 @@ export function NavbarResizer({
 
   return (
     <div
+      ref={separatorRef}
       role="separator"
       aria-orientation="vertical"
       aria-valuenow={width}

--- a/src/components/layout/NavbarResizer.tsx
+++ b/src/components/layout/NavbarResizer.tsx
@@ -113,7 +113,12 @@ export function NavbarResizer({
     // The useEffect cleanup below removes the class synchronously on unmount,
     // so an in-flight RAF that fires after unmount is a harmless no-op.
     requestAnimationFrame(() => {
-      document.body.classList.remove("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
+      // Guard against a new drag starting before this RAF fires.
+      // If draggingRef is true, the new drag's pointerDown has already
+      // re-set the class; do not clear it.
+      if (!draggingRef.current) {
+        document.body.classList.remove("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
+      }
     });
     // aria-valuenow will be set correctly by React on the next render after
     // onCommit triggers setLiveWidth(final) in the parent.

--- a/src/components/layout/NavbarResizer.tsx
+++ b/src/components/layout/NavbarResizer.tsx
@@ -66,6 +66,16 @@ export function NavbarResizer({
       currentWidthRef.current = width;
     }
   }, [width]);
+
+  // Cleanup guard: if NavbarResizer unmounts while a drag is in flight
+  // (e.g., hot-reload, route change, error boundary), the "is-resizing"
+  // class must be removed so Terminal's ResizeObserver resumes normally.
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
+    };
+  }, []);
+
   // Ref to the separator element for direct aria-valuenow mutation during drag.
   // Because the parent no longer updates liveWidth on every pointermove (to avoid
   // React re-renders that cause the terminal blink), aria-valuenow would otherwise
@@ -78,6 +88,7 @@ export function NavbarResizer({
     draggingRef.current = true;
     startClientXRef.current = e.clientX;
     startWidthRef.current = currentWidthRef.current;
+    document.body.classList.add("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
   }
 
   function handlePointerMove(e: React.PointerEvent<HTMLDivElement>) {
@@ -94,6 +105,7 @@ export function NavbarResizer({
     if (!draggingRef.current) return;
     draggingRef.current = false;
     e.currentTarget.releasePointerCapture(e.pointerId);
+    document.body.classList.remove("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
     onCommit(currentWidthRef.current);
     // aria-valuenow will be set correctly by React on the next render after
     // onCommit triggers setLiveWidth(final) in the parent.

--- a/src/components/layout/NavbarResizer.tsx
+++ b/src/components/layout/NavbarResizer.tsx
@@ -105,8 +105,16 @@ export function NavbarResizer({
     if (!draggingRef.current) return;
     draggingRef.current = false;
     e.currentTarget.releasePointerCapture(e.pointerId);
-    document.body.classList.remove("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
     onCommit(currentWidthRef.current);
+    // Defer class removal to the next animation frame so the add (pointerDown)
+    // and remove are always in separate tasks. If they land in the same task,
+    // the MutationObserver batches them to a net-zero change and the
+    // falling-edge wasResizing guard in Terminal.tsx never fires.
+    // The useEffect cleanup below removes the class synchronously on unmount,
+    // so an in-flight RAF that fires after unmount is a harmless no-op.
+    requestAnimationFrame(() => {
+      document.body.classList.remove("is-resizing"); // sentinel read by Terminal.tsx's ResizeObserver gate
+    });
     // aria-valuenow will be set correctly by React on the next render after
     // onCommit triggers setLiveWidth(final) in the parent.
   }


### PR DESCRIPTION
The terminal was redrawing (~60 fps) during navbar drag because xterm's ResizeObserver called fitAddon.fit() on every CSS layout reflow triggered by the --app-shell-navbar-width CSS variable changing. This eliminates the blink entirely by adding an "is-resizing" class to document.body during drag: NavbarResizer sets it on pointerDown and clears it (via requestAnimationFrame, guarded against re-entrant drags) on pointerUp. Terminal's ResizeObserver skips fit() while the class is present; a MutationObserver fires exactly one final fit() call when the class is cleared. AppLayout.tsx was also updated to mutate the CSS variable directly (bypassing React re-renders during drag) as the first layer of the fix.