### PR TITLE
test(e2e): strengthen playwright scaffold with shared fixtures and smoke spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ To preview a specific git worktree without manually `cd`-ing into it, use `pnpm 
 
 See [TESTING.md](TESTING.md) for the full guide, including setup, configuration decisions, and coverage.
 
+### Prerequisites
+
+Before running `pnpm test:e2e`, contributors must install the Chromium browser binary:
+
+```
+npx playwright install chromium
+```
+
+See [TESTING.md § E2E Tests](TESTING.md#e2e-tests-playwright) for the full rationale.
+
 | Command         | What it runs                                       |
 | --------------- | -------------------------------------------------- |
 | `pnpm test`     | Vitest — unit and component tests (single run)     |

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,10 +64,31 @@ npx playwright install chromium
 
 This downloads the Chromium browser binary. Without it, `pnpm test:e2e` will fail with a "browser not installed" error.
 
+### Shared fixtures and helper convention
+
+Shared helpers live in `e2e/fixtures/app-fixtures.ts`. The convention is Playwright `test.extend` fixtures rather than page-object classes — fixtures compose naturally with Playwright's built-in lifecycle, are parallel-safe by design, and avoid the stateful `this` coupling that page-object classes introduce.
+
+Every spec should import `{ test, expect }` from `./fixtures/app-fixtures` rather than from `@playwright/test` directly. This ensures all specs use the extended test runner with the shared fixtures available on the test-context argument.
+
+Currently available fixture:
+
+- **`addTerminalCard(page)`** — clicks the "Add card menu" button, selects "Terminal", and awaits `[data-testid="terminal-root"]`. Example usage:
+
+  ```ts
+  test("my test", async ({ page, addTerminalCard }) => {
+    await page.goto("/");
+    await addTerminalCard(page);
+    // terminal is now mounted
+  });
+  ```
+
+See `e2e/smoke.spec.ts` for the canonical template when writing a new spec.
+
 ### E2E specs
 
 | Spec file                             | What it covers                                                                                                                                                                                         |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `e2e/smoke.spec.ts`                   | Boots the dev server and asserts the empty-state element is visible on first load — minimal smoke test and copy-paste template for new e2e authors.                                                    |
 | `e2e/terminal-font-rendering.spec.ts` | Boots the dev server, adds a terminal card, and asserts `document.fonts.check('13px "MesloLGS NF"')` returns `true` — verifying the MesloLGS NF font is loaded before `term.open()` fires (issue #32). |
 
 ## Coverage

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -51,9 +51,15 @@ ai-dungeon/
 │   ├── icons/        # App icons (all sizes)
 │   ├── Cargo.toml
 │   └── tauri.conf.json
+├── e2e/                  # Playwright end-to-end tests (run against the Vite dev server on port 1420)
+│   ├── fixtures/
+│   │   └── app-fixtures.ts   # Shared fixture module — extends Playwright's `test` with project-wide helpers (e.g., `addTerminalCard`). Import `{ test, expect }` from here in every spec; never import directly from `@playwright/test`.
+│   ├── smoke.spec.ts         # Baseline smoke spec; also serves as a copy-paste template for new e2e authors. See the module-level JSDoc for authoring conventions.
+│   └── terminal-font-rendering.spec.ts  # MesloLGS NF font-loading regression test — asserts `document.fonts.check('13px "MesloLGS NF"')` after a terminal card mounts.
 ├── scripts/
 │   └── dev-worktree.sh   # Worktree dev launcher — validates the named worktree under `.worktrees/`, checks port 1420, runs `pnpm install --prefer-offline`, then `exec`s `pnpm tauri dev`. Invoked via `pnpm dev:worktree <name>`.
 ├── index.html
+├── playwright.config.ts  # Playwright e2e config — `testDir: ./e2e`, Vite dev server on port 1420, Chromium-only project.
 ├── vite.config.ts
 ├── tsconfig.json
 └── package.json

--- a/e2e/fixtures/app-fixtures.ts
+++ b/e2e/fixtures/app-fixtures.ts
@@ -1,0 +1,39 @@
+/**
+ * app-fixtures.ts
+ *
+ * Shared fixture module for all e2e specs in this project.
+ *
+ * Convention: shared helpers are expressed as Playwright `test.extend` fixtures
+ * rather than page-object classes. Fixtures compose naturally with Playwright's
+ * built-in lifecycle (setup/teardown, parallelism, worker reuse), are
+ * parallel-safe by design, and avoid the stateful `this` coupling that
+ * page-object classes introduce.
+ *
+ * Adding a new shared interaction: add a new fixture entry to the `fixtures`
+ * object passed to `test.extend`, export nothing else from this file, and
+ * import `{ test, expect }` from this module in every spec that needs it.
+ *
+ * NOTE: This file must NOT end in `.spec.ts`. Playwright's default test
+ * discovery pattern matches `**\/*.spec.ts`; a non-spec name ensures this
+ * module is treated as a plain TypeScript file and not executed as a test suite.
+ */
+
+import { test as base, expect, type Page } from "@playwright/test";
+
+type AppFixtures = {
+  /** Adds a terminal card via the "Add card menu" UI and waits for it to mount. */
+  addTerminalCard: (page: Page) => Promise<void>;
+};
+
+export const test = base.extend<AppFixtures>({
+  // eslint-disable-next-line no-empty-pattern
+  addTerminalCard: async ({}, use) => {
+    await use(async (page: Page) => {
+      await page.getByRole("button", { name: "Add card menu" }).click();
+      await page.getByRole("menuitem", { name: "Terminal" }).click();
+      await page.waitForSelector('[data-testid="terminal-root"]');
+    });
+  },
+});
+
+export { expect };

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * smoke.spec.ts
+ *
+ * Intentionally minimal smoke test — serves as a copy-paste template for new
+ * e2e authors. This spec asserts only that the app loads and renders its
+ * initial empty state, establishing a baseline before any interaction.
+ *
+ * Template conventions for new specs:
+ *   (a) Import `{ test, expect }` from `./fixtures/app-fixtures` — never from
+ *       `@playwright/test` directly. The fixture module is the single source of
+ *       truth for shared helpers and the extended test runner.
+ *   (b) Call `await page.goto("/")` first in every test to ensure a clean
+ *       navigation baseline.
+ *   (c) Prefer `getByRole` / `getByTestId` over CSS selectors. Role-based and
+ *       testid-based queries are resilient to style refactors and convey intent.
+ *   (d) If you find yourself copy-pasting an interaction sequence (e.g., adding
+ *       a card) into multiple specs, add it as a fixture in
+ *       `e2e/fixtures/app-fixtures.ts` instead.
+ */
+
+import { test, expect } from "./fixtures/app-fixtures";
+
+test.describe("smoke", () => {
+  test("app loads at baseURL", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByTestId("main-empty-state")).toBeVisible();
+  });
+});

--- a/e2e/terminal-font-rendering.spec.ts
+++ b/e2e/terminal-font-rendering.spec.ts
@@ -25,18 +25,17 @@
  *   5. Run `locale` — LC_CTYPE and LC_ALL both contain UTF-8.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./fixtures/app-fixtures";
 
 test.describe("MesloLGS NF font loading", () => {
-  test("MesloLGS NF is loaded in document.fonts after a terminal card mounts", async ({ page }) => {
+  test("MesloLGS NF is loaded in document.fonts after a terminal card mounts", async ({
+    page,
+    addTerminalCard,
+  }) => {
     await page.goto("/");
 
     // Add a card so a <Terminal> component mounts and triggers font loading.
-    await page.getByRole("button", { name: "Add card menu" }).click();
-    await page.getByRole("menuitem", { name: "Terminal" }).click();
-
-    // Wait for the terminal root to appear, confirming the component mounted.
-    await page.waitForSelector('[data-testid="terminal-root"]');
+    await addTerminalCard(page);
 
     // Primary assertion: MesloLGS NF must be fully loaded at the target font
     // size (13px — matches the fontSize passed to the XTerm constructor).


### PR DESCRIPTION
The existing Playwright scaffold had a single spec that inlined its setup steps, leaving future contributors with no shared helpers or template to follow. This PR extracts the repeated interaction into a shared `test.extend` fixture module and adds a minimal smoke spec that doubles as a copy-paste template, so new e2e authors have a clear pattern to follow from the start.

Documentation is synced: `README.md` now includes the `playwright install chromium` prerequisite (previously only in `TESTING.md`), and `TESTING.md` documents the fixture convention with a one-line code example.

The compiled-binary Tauri-driver path is intentionally deferred and tracked in the open-questions file.
